### PR TITLE
Better handler for XHR onerror

### DIFF
--- a/src/Network/HTTP/Affjax.purs
+++ b/src/Network/HTTP/Affjax.purs
@@ -161,7 +161,7 @@ foreign import unsafeAjax
         }
       }
       xhr.onerror = function (err) {
-        errback(new Error("AJAX request failed"))();
+        errback(new Error("AJAX request failed: " + options.method + " " + options.url))();
       };
       xhr.onload = function () {
         callback({

--- a/src/Network/HTTP/Affjax.purs
+++ b/src/Network/HTTP/Affjax.purs
@@ -161,7 +161,7 @@ foreign import unsafeAjax
         }
       }
       xhr.onerror = function (err) {
-        errback(err)();
+        errback(new Error("AJAX request failed"))();
       };
       xhr.onload = function () {
         callback({

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -34,3 +34,6 @@ main = launchAff $ do
 
   res <- attempt $ get "/arrayview"
   liftEff $ either traceAny (traceAny :: AffjaxResponse Foreign -> _) res
+
+  res <- attempt $ get "ttp://www.google.com"
+  liftEff $ either traceAny (traceAny :: AffjaxResponse Foreign -> _) res


### PR DESCRIPTION
Resolves #10 

It doesn't seem that there is much real information we can get when `onerror` occurs. I looked into using `status` or `statusText`, but they are `0` and `""` when `onerror` fires, as they are populated when a request completes successfully.

At least now the object returned actually is an `Error`, and has a somewhat meaningful message.