### PR TITLE
Better fix for IE JSON responseType

### DIFF
--- a/src/Network/HTTP/Affjax/Response.purs
+++ b/src/Network/HTTP/Affjax/Response.purs
@@ -4,9 +4,8 @@ module Network.HTTP.Affjax.Response
   , Respondable, responseType, fromResponse
   ) where
 
-import Control.Bind ((>=>))
 import Data.Either (Either(..))
-import Data.Foreign (Foreign(), F(), readString, parseJSON, unsafeReadTagged)
+import Data.Foreign (Foreign(), F(), readString, unsafeReadTagged)
 import DOM (Document())
 import DOM.File (Blob())
 import DOM.XHR (FormData())
@@ -64,7 +63,7 @@ instance responsableDocument :: Respondable Document where
 
 instance responsableJSON :: Respondable Foreign where
   responseType = JSONResponse
-  fromResponse = readString >=> parseJSON
+  fromResponse = Right
 
 instance responsableString :: Respondable String where
   responseType = StringResponse


### PR DESCRIPTION
The previous fix for this was less than ideal, as using `JSONResponse` in custom `Respondable` instances resulted in it coming through as a string regardless. Here is a workaround to pre-process the response in the JSON case instead.