### PR TITLE
node.js support, via npm package 'xmlhttprequest'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ install:
   - npm install && bower install
 script:
   - gulp
+  - node ./test-server.js &
+  - node tmp/test.js

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "gulp-plumber": "^1.0.0",
     "gulp-purescript": "^0.5.0",
     "express": "^4.13.1",
-    "body-parser": "^1.13.2"
+    "body-parser": "^1.13.2",
+    "xmlhttprequest": "^1.7.0"
   }
 }


### PR DESCRIPTION
Fixes #29. This passes all the tests in my other PR, but currently you have to set up an http server on port 80 to proxy to the test server to get them to work.