### PR TITLE
Use module.require to prevent bundling for browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "gulp-jscs": "^1.6.0",
     "gulp-jshint": "^1.11.2",
     "gulp-plumber": "^1.0.0",
-    "gulp-purescript": "^0.5.0",
+    "gulp-purescript": "^0.6.0",
     "express": "^4.13.1",
     "body-parser": "^1.13.2",
     "xmlhttprequest": "^1.7.0"

--- a/src/Network/HTTP/Affjax.js
+++ b/src/Network/HTTP/Affjax.js
@@ -1,6 +1,5 @@
 /* global exports */
 /* global XMLHttpRequest */
-/* global require */
 /* global module */
 "use strict";
 
@@ -12,12 +11,12 @@ exports._ajax = function (mkHeader, options, canceler, errback, callback) {
   if (typeof module !== "undefined" && module.exports) {
     // We are on node.js
     platformSpecific.newXHR = function () {
-      var XHR = require("xmlhttprequest").XMLHttpRequest;
+      var XHR = module.require("xmlhttprequest").XMLHttpRequest;
       return new XHR();
     };
 
     platformSpecific.fixupUrl = function (url) {
-      var urllib = require("url");
+      var urllib = module.require("url");
       var u = urllib.parse(url);
       u.protocol = u.protocol || "http:";
       u.hostname = u.hostname || "localhost";


### PR DESCRIPTION
This is a slightly sneaky trick to prevent webpack, etc. attempting to bundle node's `url` and `xmlhttprequest` modules in the JS when bundling for the browser.