### PR TITLE
Detect node with module.require

### DIFF
--- a/src/Network/HTTP/Affjax.js
+++ b/src/Network/HTTP/Affjax.js
@@ -8,7 +8,7 @@
 // jshint maxparams: 5
 exports._ajax = function (mkHeader, options, canceler, errback, callback) {
   var platformSpecific = { };
-  if (typeof module !== "undefined" && module.exports) {
+  if (typeof module !== "undefined" && module.require) {
     // We are on node.js
     platformSpecific.newXHR = function () {
       var XHR = module.require("xmlhttprequest").XMLHttpRequest;


### PR DESCRIPTION
After bundling this `if` condition was becoming true in the browser too.

It definitely works this time, I `bower link`ed it into the slamdata build to test.