### PR TITLE
[Retries] add RetryPolicy (#40)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,6 +30,7 @@
     "purescript-integers": "^0.2.0",
     "purescript-math": "^0.2.0",
     "purescript-nullable": "^0.2.0",
+    "purescript-refs": "^0.2.0",
     "purescript-unsafe-coerce": "^0.1.0"
   },
   "devDependencies": {

--- a/docs/Network.HTTP.Affjax.md
+++ b/docs/Network.HTTP.Affjax.md
@@ -144,13 +144,29 @@ delete_ :: forall e. URL -> Affjax e Unit
 
 Makes a `DELETE` request to the specified URL and ignores the response.
 
+#### `RetryPolicy`
+
+``` purescript
+type RetryPolicy = { timeout :: Maybe Int, delayCurve :: RetryDelayCurve, shouldRetryWithStatusCode :: StatusCode -> Boolean }
+```
+
+Expresses a policy for retrying Affjax requests with backoff.
+
+#### `defaultRetryPolicy`
+
+``` purescript
+defaultRetryPolicy :: RetryPolicy
+```
+
+A sensible default for retries: no timeout, maximum delay of 30s, initial delay of 0.1s, exponential backoff, and no status code triggers a retry.
+
 #### `retry`
 
 ``` purescript
-retry :: forall e a b. (Requestable a) => Maybe Int -> (AffjaxRequest a -> Affjax (avar :: AVAR | e) b) -> AffjaxRequest a -> Affjax (avar :: AVAR | e) b
+retry :: forall e a b. (Requestable a) => RetryPolicy -> (AffjaxRequest a -> Affjax (avar :: AVAR | e) b) -> AffjaxRequest a -> Affjax (avar :: AVAR | e) b
 ```
 
-Retry a request with exponential backoff, timing out optionally after a specified number of milliseconds. After the timeout, the last received response is returned; if it was not possible to communicate with the server due to an error, then this is bubbled up.
+Retry a request using a `RetryPolicy`. After the timeout, the last received response is returned; if it was not possible to communicate with the server due to an error, then this is bubbled up.
 
 #### `affjax'`
 

--- a/docs/Network.HTTP.Affjax.md
+++ b/docs/Network.HTTP.Affjax.md
@@ -171,7 +171,7 @@ A sensible default for retries: no timeout, maximum delay of 30s, initial delay 
 #### `retry`
 
 ``` purescript
-retry :: forall e a b. (Requestable a) => RetryPolicy -> (AffjaxRequest a -> Affjax (avar :: AVAR | e) b) -> AffjaxRequest a -> Affjax (avar :: AVAR | e) b
+retry :: forall e a b. (Requestable a) => RetryPolicy -> (AffjaxRequest a -> Affjax (avar :: AVAR, ref :: REF | e) b) -> AffjaxRequest a -> Affjax (avar :: AVAR, ref :: REF | e) b
 ```
 
 Retry a request using a `RetryPolicy`. After the timeout, the last received response is returned; if it was not possible to communicate with the server due to an error, then this is bubbled up.

--- a/docs/Network.HTTP.Affjax.md
+++ b/docs/Network.HTTP.Affjax.md
@@ -144,6 +144,14 @@ delete_ :: forall e. URL -> Affjax e Unit
 
 Makes a `DELETE` request to the specified URL and ignores the response.
 
+#### `RetryDelayCurve`
+
+``` purescript
+type RetryDelayCurve = Int -> Int
+```
+
+A sequence of retry delays, in milliseconds.
+
 #### `RetryPolicy`
 
 ``` purescript

--- a/src/Network/HTTP/Affjax.purs
+++ b/src/Network/HTTP/Affjax.purs
@@ -10,6 +10,7 @@ module Network.HTTP.Affjax
   , post, post_, post', post_'
   , put, put_, put', put_'
   , delete, delete_
+  , RetryDelayCurve()
   , RetryPolicy(..)
   , defaultRetryPolicy
   , retry

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -64,9 +64,10 @@ main = runAff (\e -> print e >>= \_ -> throwException e) (const $ log "affjax: A
   let mirror       = prefix "/mirror"
   let doesNotExist = prefix "/does-not-exist"
   let notJson      = prefix "/not-json"
+  let retryPolicy = defaultRetryPolicy { timeout = Just 500, shouldRetryWithStatusCode = \_ -> true }
 
   A.log "GET /does-not-exist: should be 404 Not found after retries"
-  (attempt $ retry (Just 5000) affjax $ defaultRequest { url = doesNotExist }) >>= assertRight >>= \res -> do
+  (attempt $ retry retryPolicy affjax $ defaultRequest { url = doesNotExist }) >>= assertRight >>= \res -> do
     typeIs (res :: AffjaxResponse String)
     assertEq notFound404 res.status
 


### PR DESCRIPTION
This resolves #40.

This is a breaking API change, so an alternative would be to keep the old interface for compatibility, and add a new combinator, `retryWithPolicy`. What do folks think?