### PR TITLE
Addressed https://github.com/slamdata/purescript-affjax/issues/5

### DIFF
--- a/src/Network/HTTP/Affjax/Response.purs
+++ b/src/Network/HTTP/Affjax/Response.purs
@@ -72,3 +72,7 @@ instance responsableString :: Respondable String where
 instance responsableUnit :: Respondable Unit where
   responseType = StringResponse
   fromResponse = const (Right unit)
+
+instance responsableArrayBuffer :: Respondable A.ArrayBuffer where
+  responseType = ArrayBufferResponse
+  fromResponse = unsafeReadTagged "ArrayBuffer"


### PR DESCRIPTION
Resolves #5

In the process of upgrading https://github.com/waterson/purescript-webaudio to compile under PureScript 0.7.x, and trying to get one of its tests to pass, I needed to have an instance of Respondable for ArrayBuffer available to me when issuing a get:

 affjaxResponse <- get "/a_sound.wav" :: Aff ( ajax :: AJAX ) (AffjaxResponse ArrayBuffer)

Ultimately a call to decodeAudioData in JavaScript is made to play a sound, and indeed it needs an ArrayBuffer passed to it: https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/decodeAudioData. I did try using an AffjaxResponse Blob, but that didn't work. I also tried just creating a local instance but PureScript disallows so-called "orphan instances".

If there is a better, less invasive way to accomplish this, let me know; I just figured that this sufficed as a use case for the issue nominated above.