### PR TITLE
Replace xmlhttprequest module with xhr2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 script:
   - gulp
   - node ./test-server.js &
-  - node tmp/test.js
+  - sleep 2 && node tmp/test.js

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ bower install purescript-affjax
 If you are intending to use the library in a Node.js setting rather than the browser, you will need an additional dependency from `npm`:
 
 ```
-npm install xmlhttprequest
+npm install xhr2
 ```
 
 ## Introduction

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "gulp-plumber": "^1.0.0",
     "gulp-purescript": "^0.6.0",
     "purescript": "^0.7.4-rc.2",
-    "xmlhttprequest": "^1.7.0"
+    "xhr2": "^0.1.3"
   }
 }

--- a/src/Network/HTTP/Affjax.js
+++ b/src/Network/HTTP/Affjax.js
@@ -11,7 +11,7 @@ exports._ajax = function (mkHeader, options, canceler, errback, callback) {
   if (typeof module !== "undefined" && module.require) {
     // We are on node.js
     platformSpecific.newXHR = function () {
-      var XHR = module.require("xmlhttprequest").XMLHttpRequest;
+      var XHR = module.require("xhr2");
       return new XHR();
     };
 
@@ -24,8 +24,7 @@ exports._ajax = function (mkHeader, options, canceler, errback, callback) {
     };
 
     platformSpecific.getResponse = function (xhr) {
-      // the node package 'xmlhttprequest' does not support xhr.response.
-      return xhr.responseText;
+      return xhr.response;
     };
   } else {
     // We are in the browser


### PR DESCRIPTION
Fixes #44 by replacing use of the Node ```xmlhttprequest``` module with ```xhr2```.

This only affects those running purescript-affjax on Node, not in the browser. They will need to install the ```xhr2``` package as a local npm dependency instead of ```xmlhttprequest```.

This is therefore a breaking change for them. However, we could preserve backwards compatibility by adding an extra couple of lines to still use the ```xmlhttprequest``` package as a fallback if ```xhr2``` isn't found.
