### PR TITLE
Include mime types in Requestable/Respondable for setting headers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
   ],
   "dependencies": {
     "purescript-aff": "^0.13.0",
+    "purescript-argonaut-core": "^0.2.0",
     "purescript-arraybuffer-types": "^0.2.0",
     "purescript-dom": "^0.2.0",
     "purescript-foreign": "^0.7.0",

--- a/docs/Network.HTTP.Affjax.Request.md
+++ b/docs/Network.HTTP.Affjax.Request.md
@@ -18,11 +18,12 @@ instance requestableRequestContent :: Requestable RequestContent
 
 ``` purescript
 class Requestable a where
-  toRequest :: a -> RequestContent
+  toRequest :: a -> Tuple (Maybe MimeType) RequestContent
 ```
 
 A class for types that can be converted to values that can be sent with
-XHR requests.
+XHR requests. An optional mime-type can be specified for a default
+`Content-Type` header.
 
 ##### Instances
 ``` purescript
@@ -39,6 +40,7 @@ instance requestableFloat64Array :: Requestable (ArrayView Float64)
 instance requestableBlob :: Requestable Blob
 instance requestableDocument :: Requestable Document
 instance requestableString :: Requestable String
+instance requestableJson :: Requestable Json
 instance requestableFormData :: Requestable FormData
 instance requestableUnit :: Requestable Unit
 ```

--- a/docs/Network.HTTP.Affjax.Response.md
+++ b/docs/Network.HTTP.Affjax.Response.md
@@ -35,13 +35,14 @@ type ResponseContent = Foreign
 ```
 
 Type representing content types that be received from an XHR request
-(Blob, Document, JSON, String).
+(Blob, Document, JSON, String). An optional mime-type can be specified for
+a default `Accept` header.
 
 #### `Respondable`
 
 ``` purescript
 class Respondable a where
-  responseType :: ResponseType a
+  responseType :: Tuple (Maybe MimeType) (ResponseType a)
   fromResponse :: ResponseContent -> F a
 ```
 

--- a/docs/Network.HTTP.Affjax.Response.md
+++ b/docs/Network.HTTP.Affjax.Response.md
@@ -49,9 +49,11 @@ class Respondable a where
 ``` purescript
 instance responsableBlob :: Respondable Blob
 instance responsableDocument :: Respondable Document
-instance responsableJSON :: Respondable Foreign
+instance responsableForeign :: Respondable Foreign
 instance responsableString :: Respondable String
 instance responsableUnit :: Respondable Unit
+instance responsableArrayBuffer :: Respondable ArrayBuffer
+instance responsableJson :: Respondable Json
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "gulp-jshint": "^1.11.2",
     "gulp-plumber": "^1.0.0",
     "gulp-purescript": "^0.6.0",
-    "purescript": "^0.7.4-rc.2",
+    "purescript": "^0.7.5",
     "xhr2": "^0.1.3"
   }
 }

--- a/src/Network/HTTP/Affjax/Request.purs
+++ b/src/Network/HTTP/Affjax/Request.purs
@@ -4,62 +4,78 @@ module Network.HTTP.Affjax.Request
   ) where
 
 import Prelude
+
+import Data.Argonaut.Core (Json())
+import Data.Maybe (Maybe(..))
+import Data.Tuple (Tuple(..))
+import qualified Data.ArrayBuffer.Types as A
+
 import DOM.File.Types (Blob())
 import DOM.Node.Types (Document())
 import DOM.XHR.Types (FormData())
+
 import qualified Unsafe.Coerce as U
-import qualified Data.ArrayBuffer.Types as A
+
+import Network.HTTP.MimeType (MimeType())
+import Network.HTTP.MimeType.Common (applicationJSON)
 
 -- | Type representing all content types that be sent via XHR (ArrayBufferView,
 -- | Blob, Document, String, FormData).
 foreign import data RequestContent :: *
 
 -- | A class for types that can be converted to values that can be sent with
--- | XHR requests.
+-- | XHR requests. An optional mime-type can be specified for a default
+-- | `Content-Type` header.
 class Requestable a where
-  toRequest :: a -> RequestContent
+  toRequest :: a -> Tuple (Maybe MimeType) RequestContent
+
+defaultToRequest :: forall a. a -> Tuple (Maybe MimeType) RequestContent
+defaultToRequest = Tuple Nothing <<< U.unsafeCoerce
 
 instance requestableRequestContent :: Requestable RequestContent where
-  toRequest = id
+  toRequest = defaultToRequest
 
 instance requestableInt8Array :: Requestable (A.ArrayView A.Int8) where
-  toRequest = U.unsafeCoerce
+  toRequest = defaultToRequest
 
 instance requestableInt16Array :: Requestable (A.ArrayView A.Int16) where
-  toRequest = U.unsafeCoerce
+  toRequest = defaultToRequest
 
 instance requestableInt32Array :: Requestable (A.ArrayView A.Int32) where
-  toRequest = U.unsafeCoerce
+  toRequest = defaultToRequest
 
 instance requestableUint8Array :: Requestable (A.ArrayView A.Uint8) where
-  toRequest = U.unsafeCoerce
+  toRequest = defaultToRequest
 
 instance requestableUint16Array :: Requestable (A.ArrayView A.Uint16) where
-  toRequest = U.unsafeCoerce
+  toRequest = defaultToRequest
 
 instance requestableUint32Array :: Requestable (A.ArrayView A.Uint32) where
-  toRequest = U.unsafeCoerce
+  toRequest = defaultToRequest
 
 instance requestableUint8ClampedArray :: Requestable (A.ArrayView A.Uint8Clamped) where
-  toRequest = U.unsafeCoerce
+  toRequest = defaultToRequest
 
 instance requestableFloat32Array :: Requestable (A.ArrayView A.Float32) where
-  toRequest = U.unsafeCoerce
+  toRequest = defaultToRequest
 
 instance requestableFloat64Array :: Requestable (A.ArrayView A.Float64) where
-  toRequest = U.unsafeCoerce
+  toRequest = defaultToRequest
 
 instance requestableBlob :: Requestable Blob where
-  toRequest = U.unsafeCoerce
+  toRequest = defaultToRequest
 
 instance requestableDocument :: Requestable Document where
-  toRequest = U.unsafeCoerce
+  toRequest = defaultToRequest
 
 instance requestableString :: Requestable String where
-  toRequest = U.unsafeCoerce
+  toRequest = defaultToRequest
+
+instance requestableJson :: Requestable Json where
+  toRequest json = Tuple (Just applicationJSON) (U.unsafeCoerce (show json))
 
 instance requestableFormData :: Requestable FormData where
-  toRequest = U.unsafeCoerce
+  toRequest = defaultToRequest
 
 instance requestableUnit :: Requestable Unit where
-  toRequest = U.unsafeCoerce
+  toRequest = defaultToRequest

--- a/src/Network/HTTP/Affjax/Response.purs
+++ b/src/Network/HTTP/Affjax/Response.purs
@@ -5,12 +5,17 @@ module Network.HTTP.Affjax.Response
   ) where
 
 import Prelude
+
+import Data.Argonaut.Core (Json())
 import Data.Either (Either(..))
 import Data.Foreign (Foreign(), F(), readString, unsafeReadTagged)
+import qualified Data.ArrayBuffer.Types as A
+
 import DOM.File.Types (Blob())
 import DOM.Node.Types (Document())
 import DOM.XHR.Types (FormData())
-import qualified Data.ArrayBuffer.Types as A
+
+import Unsafe.Coerce (unsafeCoerce)
 
 -- | Valid response types for an AJAX request. This is used to determine the
 -- | `ResponseContent` type for a request. The `a` type variable is a phantom
@@ -61,7 +66,7 @@ instance responsableDocument :: Respondable Document where
   responseType = DocumentResponse
   fromResponse = unsafeReadTagged "Document"
 
-instance responsableJSON :: Respondable Foreign where
+instance responsableForeign :: Respondable Foreign where
   responseType = JSONResponse
   fromResponse = Right
 
@@ -76,3 +81,7 @@ instance responsableUnit :: Respondable Unit where
 instance responsableArrayBuffer :: Respondable A.ArrayBuffer where
   responseType = ArrayBufferResponse
   fromResponse = unsafeReadTagged "ArrayBuffer"
+
+instance responsableJson :: Respondable Json where
+  responseType = JSONResponse
+  fromResponse = Right <<< unsafeCoerce


### PR DESCRIPTION
What do you think of this @jdegoes?

Using a `Maybe MimeType` allows us to take advantage of the browser constructing the correct header for `FormData` and the like (generating a boundary, etc.) but allow us to specify our own in cases where the content is not a standard XHR thing, like JSON.

The `Accept` and `Content-Type` can still be specified manually in the request, and will take precedence over the values provided by the instances.

Resolves #8, resolves #6.