### PR TITLE
Parse response JSON before coercing to argonaut Json object.

### DIFF
--- a/src/Network/HTTP/Affjax/Response.purs
+++ b/src/Network/HTTP/Affjax/Response.purs
@@ -92,4 +92,4 @@ instance responsableArrayBuffer :: Respondable A.ArrayBuffer where
 
 instance responsableJson :: Respondable Json where
   responseType = Tuple (Just applicationJSON) JSONResponse
-  fromResponse = Right <<< unsafeCoerce
+  fromResponse = unsafeCoerce (parseJSON <=< readString)


### PR DESCRIPTION
I believe this got lost in 9b66ff7181ef28cc5a7ec4b83ea33746467a4069.