### PR TITLE
Restore parse fix for JSON responses

### DIFF
--- a/src/Network/HTTP/Affjax.purs
+++ b/src/Network/HTTP/Affjax.purs
@@ -18,6 +18,7 @@ module Network.HTTP.Affjax
 
 import Prelude
 
+import Control.Bind ((<=<))
 import Control.Monad.Aff (Aff(), makeAff, makeAff', Canceler(..), attempt, later', forkAff, cancel)
 import Control.Monad.Aff.AVar (AVAR(), makeVar, takeVar, putVar)
 import Control.Monad.Eff (Eff())
@@ -28,7 +29,7 @@ import Control.Monad.Error.Class (throwError)
 
 import Data.Array as Arr
 import Data.Either (Either(..), either)
-import Data.Foreign (Foreign())
+import Data.Foreign (Foreign(), F(), parseJSON, readString)
 import Data.Foldable (any)
 import Data.Function (Fn5(), runFn5, Fn4(), runFn4, on)
 import Data.Int (toNumber, round)
@@ -239,9 +240,14 @@ affjax' req eb cb =
     _ -> hs
 
   cb' :: AffjaxResponse ResponseContent -> Eff (ajax :: AJAX | e) Unit
-  cb' res = case res { response = _  } <$> fromResponse res.response of
+  cb' res = case res { response = _  } <$> fromResponse' res.response of
     Left err -> eb $ error (show err)
     Right res' -> cb res'
+
+  fromResponse' :: ResponseContent -> F b
+  fromResponse' = case snd responseSettings of
+    JSONResponse -> fromResponse <=< parseJSON <=< readString
+    _ -> fromResponse
 
 type AjaxRequest =
   { method :: String

--- a/src/Network/HTTP/Affjax/Response.purs
+++ b/src/Network/HTTP/Affjax/Response.purs
@@ -17,7 +17,6 @@ import qualified Data.ArrayBuffer.Types as A
 
 import DOM.File.Types (Blob())
 import DOM.Node.Types (Document())
-import DOM.XHR.Types (FormData())
 
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -76,7 +75,7 @@ instance responsableDocument :: Respondable Document where
 
 instance responsableForeign :: Respondable Foreign where
   responseType = Tuple Nothing JSONResponse
-  fromResponse = parseJSON <=< readString
+  fromResponse = Right <<< unsafeCoerce
 
 instance responsableString :: Respondable String where
   responseType = Tuple Nothing StringResponse

--- a/src/Network/HTTP/StatusCode.purs
+++ b/src/Network/HTTP/StatusCode.purs
@@ -2,8 +2,6 @@ module Network.HTTP.StatusCode where
 
 import Prelude
 
-import Data.Int
-
 newtype StatusCode = StatusCode Int
 
 instance eqStatusCode :: Eq StatusCode where


### PR DESCRIPTION
Resolves #55 - @cdepillabout thanks, it wasn't changed intentionally, I'm not sure how it got lost

Resolves #54 - @teh the code you noticed went missing was replaced with this that also went missing at some point, I think this is a better fix as it will automatically apply the fix for any JSONResponse rather than having to handle it in every instance that expects it.