### PR TITLE
Update build, fix warnings

### DIFF
--- a/docs/Network.HTTP.Affjax.Request.md
+++ b/docs/Network.HTTP.Affjax.Request.md
@@ -11,7 +11,7 @@ Blob, Document, String, FormData).
 
 ##### Instances
 ``` purescript
-instance requestableRequestContent :: Requestable RequestContent
+Requestable RequestContent
 ```
 
 #### `Requestable`
@@ -27,22 +27,22 @@ XHR requests. An optional mime-type can be specified for a default
 
 ##### Instances
 ``` purescript
-instance requestableRequestContent :: Requestable RequestContent
-instance requestableInt8Array :: Requestable (ArrayView Int8)
-instance requestableInt16Array :: Requestable (ArrayView Int16)
-instance requestableInt32Array :: Requestable (ArrayView Int32)
-instance requestableUint8Array :: Requestable (ArrayView Uint8)
-instance requestableUint16Array :: Requestable (ArrayView Uint16)
-instance requestableUint32Array :: Requestable (ArrayView Uint32)
-instance requestableUint8ClampedArray :: Requestable (ArrayView Uint8Clamped)
-instance requestableFloat32Array :: Requestable (ArrayView Float32)
-instance requestableFloat64Array :: Requestable (ArrayView Float64)
-instance requestableBlob :: Requestable Blob
-instance requestableDocument :: Requestable Document
-instance requestableString :: Requestable String
-instance requestableJson :: Requestable Json
-instance requestableFormData :: Requestable FormData
-instance requestableUnit :: Requestable Unit
+Requestable RequestContent
+Requestable (ArrayView Int8)
+Requestable (ArrayView Int16)
+Requestable (ArrayView Int32)
+Requestable (ArrayView Uint8)
+Requestable (ArrayView Uint16)
+Requestable (ArrayView Uint32)
+Requestable (ArrayView Uint8Clamped)
+Requestable (ArrayView Float32)
+Requestable (ArrayView Float64)
+Requestable Blob
+Requestable Document
+Requestable String
+Requestable Json
+Requestable FormData
+Requestable Unit
 ```
 
 

--- a/docs/Network.HTTP.Affjax.Response.md
+++ b/docs/Network.HTTP.Affjax.Response.md
@@ -18,8 +18,8 @@ type used to associate the `ResponseType` with a particular instance of
 
 ##### Instances
 ``` purescript
-instance eqResponseType :: Eq (ResponseType a)
-instance showResponseType :: Show (ResponseType a)
+Eq (ResponseType a)
+Show (ResponseType a)
 ```
 
 #### `responseTypeToString`
@@ -48,13 +48,13 @@ class Respondable a where
 
 ##### Instances
 ``` purescript
-instance responsableBlob :: Respondable Blob
-instance responsableDocument :: Respondable Document
-instance responsableForeign :: Respondable Foreign
-instance responsableString :: Respondable String
-instance responsableUnit :: Respondable Unit
-instance responsableArrayBuffer :: Respondable ArrayBuffer
-instance responsableJson :: Respondable Json
+Respondable Blob
+Respondable Document
+Respondable Foreign
+Respondable String
+Respondable Unit
+Respondable ArrayBuffer
+Respondable Json
 ```
 
 

--- a/docs/Network.HTTP.Method.md
+++ b/docs/Network.HTTP.Method.md
@@ -18,8 +18,8 @@ data Method
 
 ##### Instances
 ``` purescript
-instance eqMethod :: Eq Method
-instance showMethod :: Show Method
+Eq Method
+Show Method
 ```
 
 #### `methodToString`

--- a/docs/Network.HTTP.MimeType.md
+++ b/docs/Network.HTTP.MimeType.md
@@ -9,8 +9,8 @@ newtype MimeType
 
 ##### Instances
 ``` purescript
-instance eqMimeType :: Eq MimeType
-instance showMimeType :: Show MimeType
+Eq MimeType
+Show MimeType
 ```
 
 #### `mimeTypeToString`

--- a/docs/Network.HTTP.RequestHeader.md
+++ b/docs/Network.HTTP.RequestHeader.md
@@ -11,8 +11,8 @@ data RequestHeader
 
 ##### Instances
 ``` purescript
-instance eqRequestHeader :: Eq RequestHeader
-instance showRequestHeader :: Show RequestHeader
+Eq RequestHeader
+Show RequestHeader
 ```
 
 #### `requestHeaderName`

--- a/docs/Network.HTTP.ResponseHeader.md
+++ b/docs/Network.HTTP.ResponseHeader.md
@@ -8,8 +8,8 @@ data ResponseHeader
 
 ##### Instances
 ``` purescript
-instance eqResponseHeader :: Eq ResponseHeader
-instance showResponseHeader :: Show ResponseHeader
+Eq ResponseHeader
+Show ResponseHeader
 ```
 
 #### `responseHeader`

--- a/docs/Network.HTTP.StatusCode.md
+++ b/docs/Network.HTTP.StatusCode.md
@@ -9,8 +9,8 @@ newtype StatusCode
 
 ##### Instances
 ``` purescript
-instance eqStatusCode :: Eq StatusCode
-instance showStatusCode :: Show StatusCode
+Eq StatusCode
+Show StatusCode
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "gulp-jscs": "^1.6.0",
     "gulp-jshint": "^1.11.2",
     "gulp-plumber": "^1.0.0",
-    "gulp-purescript": "^0.6.0",
-    "purescript": "^0.7.5",
+    "gulp-purescript": "^0.8.0",
+    "purescript": "^0.7.6",
     "xhr2": "^0.1.3"
   }
 }

--- a/src/Network/HTTP/Affjax/Response.purs
+++ b/src/Network/HTTP/Affjax/Response.purs
@@ -6,11 +6,9 @@ module Network.HTTP.Affjax.Response
 
 import Prelude
 
-import Control.Bind ((<=<))
-
 import Data.Argonaut.Core (Json())
 import Data.Either (Either(..))
-import Data.Foreign (Foreign(), F(), parseJSON, readString, unsafeReadTagged)
+import Data.Foreign (Foreign(), F(), readString, unsafeReadTagged)
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
 import qualified Data.ArrayBuffer.Types as A


### PR DESCRIPTION
- upgrade `purescript`, `gulp-purescript` build dependencies
- fix warnings

This warrants just a patch version release, because the only dependencies changed are not part of the `bower` distribution.