### PR TITLE
Adding support for setting XMLHttpRequest.withCredentials

### DIFF
--- a/src/Network/HTTP/Affjax.js
+++ b/src/Network/HTTP/Affjax.js
@@ -73,6 +73,7 @@ exports._ajax = function (mkHeader, options, canceler, errback, callback) {
       })();
     };
     xhr.responseType = options.responseType;
+    xhr.withCredentials = options.withCredentials;
     xhr.send(options.content);
     return canceler(xhr);
   };

--- a/src/Network/HTTP/Affjax.purs
+++ b/src/Network/HTTP/Affjax.purs
@@ -62,6 +62,7 @@ type AffjaxRequest a =
   , content :: Maybe a
   , username :: Maybe String
   , password :: Maybe String
+  , withCredentials :: Boolean
   }
 
 defaultRequest :: AffjaxRequest Unit
@@ -72,6 +73,7 @@ defaultRequest =
   , content: Nothing
   , username: Nothing
   , password: Nothing
+  , withCredentials: false
   }
 
 -- | The type of records that will be received as an Affjax response.
@@ -218,6 +220,7 @@ affjax' req eb cb =
          , responseType: responseTypeToString (snd responseSettings)
          , username: toNullable req.username
          , password: toNullable req.password
+         , withCredentials: req.withCredentials
          }
 
   requestSettings :: Tuple (Maybe MimeType) (Maybe RequestContent)
@@ -257,6 +260,7 @@ type AjaxRequest =
   , responseType :: String
   , username :: Nullable String
   , password :: Nullable String
+  , withCredentials :: Boolean
   }
 
 foreign import _ajax


### PR DESCRIPTION
Adds a [withCredentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) field to `AffjaxRequest` and the internal `AjaxRequest`, that is subsequently set on the underlying `XMLHttpRequest`.

This enables the user to allow cookies, authorisation headers, and TLS certificates to be sent with cross site Access-Control requests. This flag also allows the user to control whether response cookies (via Set-Cookie) should be ignored by the user-agent.

In theory the `Set-Cookie` test that is [commented out](https://github.com/slamdata/purescript-affjax/blob/c1d346dddfe36b3f6cc72d0e418a6d20b69a2a6a/test/Main.purs#L116) should work with the following:

```
  A.log "Testing CORS, HTTPS"
  let cors = defaultRequest
           { url             = "https://cors-test.appspot.com/test"
           , withCredentials = true
           }
  attempt (affjax cors) >>= assertRight >>= \res -> do
      typeIs (res :: AffjaxResponse Foreign)
      assertEq ok200 res.status
      assertEq (Just "test=test") $
          responseHeaderValue <$>
              find (eq "set-cookie" <<< responseHeaderName) res.headers
```

But the header is still not being returned for that particular test. Not sure if it's related to `xhr2` or not.

> Ideally there wouldn't be a need to extend each `*Request` type with additional fields - some kind of map/merge of options like JQuery's `xhrField`s as an escape hatch for the user?