### PR TITLE
Adding support for query params in url.

### DIFF
--- a/test-server.js
+++ b/test-server.js
@@ -21,6 +21,18 @@ app.get('/not-json', function(req, res) {
   res.send('This is not JSON');
 });
 
+app.all('/test-query-params', function(req, res) {
+  // request url:  /test-query-params?order=desc&shoe[color]=blue&shoe[type]=converse
+  var q = req.query;
+  if (q.order == "desc"
+      && q.shoe.color == "blue"
+      && q.shoe.type == "converse") {
+    res.sendStatus(200);
+  } else {
+    res.sendStatus(500);
+  }
+});
+
 app.all('/mirror', function(req, res) {
   res.json({
     headers: req.headers,

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -14,6 +14,7 @@ import Control.Monad.Eff.Exception
 import Data.Either
 import Data.Maybe
 import Data.Foreign
+import Data.Tuple
 import Network.HTTP.Affjax
 import Network.HTTP.StatusCode
 
@@ -92,6 +93,16 @@ main = runAff (\e -> print e >>= \_ -> throwException e) (const $ log "affjax: A
 
   A.log "GET /not-json: invalid JSON with String response should be ok"
   (attempt $ get notJson) >>= assertRight >>= \res -> do
+    typeIs (res :: AffjaxResponse String)
+    assertEq ok200 res.status
+
+  A.log "GET url query params: /test-query-params?order=desc&shoe[color]=blue&shoe[type]=converse"
+  (attempt $ affjax $
+    defaultRequest { url = prefix "/test-query-params"
+                   , queryParams = mkQueryParams [ Tuple "order" (Just "desc")
+                                                 , Tuple "shoe[color]" (Just "blue")
+                                                 , Tuple "shoe[type]" (Just "converse")]
+                   }) >>= assertRight >>= \res -> do
     typeIs (res :: AffjaxResponse String)
     assertEq ok200 res.status
 


### PR DESCRIPTION
Encoding query params is based on the library purescript-form-urlencoded.
