### PR TITLE
Bumps purescript-dom dependency to 0.2.20.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "purescript-aff": "^0.16.0",
     "purescript-argonaut-core": "^0.2.0",
     "purescript-arraybuffer-types": "^0.2.0",
-    "purescript-dom": "^0.2.0",
+    "purescript-dom": "^0.2.20",
     "purescript-foreign": "^0.7.0",
     "purescript-form-urlencoded": "^0.3.0",
     "purescript-http-methods": "^0.1.1",


### PR DESCRIPTION
(Which fixes the FFI-related errors that 0.8.4 brings to light.)