### PR TITLE
Implement customized AJAX requests

### DIFF
--- a/test/Main.purs
+++ b/test/Main.purs
@@ -121,3 +121,8 @@ main = runAff (\e -> print e >>= \_ -> throwException e) (const $ log "affjax: A
   canceler <- forkAff (post_ mirror "do it now")
   canceled <- canceler `cancel` error "Pull the cord!"
   assertMsg "Should have been canceled" canceled
+
+  A.log "Customized GET /mirror: should be 200 OK"
+  (attempt $ customAffjax (defaultRequest { url = mirror }) $ const (pure unit)) >>= assertRight >>= \res -> do
+    typeIs (res :: AffjaxResponse Foreign)
+    assertEq ok200 res.status


### PR DESCRIPTION
Proposed fix for #50.

Adds two new public functions: `customAffjax` and `customAffjax'` which allow the underlying XHR to be inspected/manipulated before it is sent. This makes it possible to add an event listener for the `progress` event, for example.

To enable this, execution of the XHR was divided into three stages:
  - preparing,
  - callback wiring,
  - sending.