### PR TITLE
Fixed bug in splitting headers

### DIFF
--- a/src/Network/HTTP/Affjax.js
+++ b/src/Network/HTTP/Affjax.js
@@ -61,7 +61,7 @@ exports._ajax = function (mkHeader, options, canceler, errback, callback) {
     xhr.onload = function () {
       callback({
         status: xhr.status,
-        headers: xhr.getAllResponseHeaders().split("\n")
+        headers: xhr.getAllResponseHeaders().split("\r\n")
           .filter(function (header) {
             return header.length > 0;
           })


### PR DESCRIPTION
First, thanks for all your work on Purescript and its libraries.  I benefit greatly from your work.

I found and fixed a nasty bug this morning...

`xhr.getAllResponseHeaders()` returns the headers separated by CRLF, not just LF.

See [here](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders) and [here](https://www.w3.org/TR/XMLHttpRequest/#the-getallresponseheaders()-method). 

Presently, `purescript-affjax` splits only on `\n`.  See [here] (https://github.com/slamdata/purescript-affjax/blob/master/src/Network/HTTP/Affjax.js#L64).

Ordinarily, it wouldn't be a problem.  But when your workflow involves extracting an 'X-Auth-Token' from the header of an AJAX response, and then sending that token value as a header value of a new AJAX request, the new request will error out if the header value contains CR (or LF).