### PR TITLE
Update dependencies.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,21 +23,21 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-aff": "^1.1.0",
-    "purescript-argonaut-core": "^1.0.0",
+    "purescript-aff": "^2.0.1",
+    "purescript-argonaut-core": "^2.0.1",
     "purescript-arraybuffer-types": "^0.2.0",
-    "purescript-dom": "^2.0.0",
-    "purescript-foreign": "^1.0.0",
-    "purescript-form-urlencoded": "^1.0.0",
-    "purescript-http-methods": "^1.0.0",
-    "purescript-integers": "^1.1.0",
+    "purescript-dom": "^3.1.0",
+    "purescript-foreign": "^3.0.0",
+    "purescript-form-urlencoded": "^2.0.0",
+    "purescript-http-methods": "^2.0.0",
+    "purescript-integers": "^2.0.0",
     "purescript-math": "^2.0.0",
-    "purescript-media-types": "^1.0.0",
-    "purescript-nullable": "^1.0.1",
-    "purescript-refs": "^1.0.0",
-    "purescript-unsafe-coerce": "^1.0.0"
+    "purescript-media-types": "^2.0.0",
+    "purescript-nullable": "^2.0.0",
+    "purescript-refs": "^2.0.0",
+    "purescript-unsafe-coerce": "^2.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^1.0.0"
+    "purescript-console": "^2.0.0"
   }
 }

--- a/src/Network/HTTP/Affjax/Response.purs
+++ b/src/Network/HTTP/Affjax/Response.purs
@@ -20,6 +20,8 @@ import DOM.Node.Types (Document())
 
 import Unsafe.Coerce (unsafeCoerce)
 
+import Control.Monad.Except (except, runExcept)
+
 -- | Valid response types for an AJAX request. This is used to determine the
 -- | `ResponseContent` type for a request. The `a` type variable is a phantom
 -- | type used to associate the `ResponseType` with a particular instance of
@@ -80,7 +82,7 @@ instance responsableString :: Respondable String where
 
 instance responsableUnit :: Respondable Unit where
   responseType = Tuple Nothing StringResponse
-  fromResponse = const (Right unit)
+  fromResponse = const (except (Right unit))
 
 instance responsableArrayBuffer :: Respondable A.ArrayBuffer where
   responseType = Tuple Nothing ArrayBufferResponse

--- a/src/Network/HTTP/RequestHeader.purs
+++ b/src/Network/HTTP/RequestHeader.purs
@@ -2,7 +2,8 @@ module Network.HTTP.RequestHeader where
 
 import Prelude
 
-import Data.MediaType (MediaType(), unMediaType)
+import Data.MediaType (MediaType())
+import Data.Newtype (unwrap)
 
 data RequestHeader
   = Accept MediaType
@@ -26,6 +27,6 @@ requestHeaderName (ContentType _) = "Content-Type"
 requestHeaderName (RequestHeader h _) = h
 
 requestHeaderValue :: RequestHeader -> String
-requestHeaderValue (Accept m) = unMediaType m
-requestHeaderValue (ContentType m) = unMediaType m
+requestHeaderValue (Accept m) = unwrap m
+requestHeaderValue (ContentType m) = unwrap m
 requestHeaderValue (RequestHeader _ v) = v


### PR DESCRIPTION
I'd like to update more dependencies in affjax to prevent diamond-dependency issues. Sound ok?

I updated the version of purescript-foreign used, but I can't figure out how to fix the type-error in Response.purs, for the Respondable instance of Json. I think we need to use `except` somewhere in there somewhere.

```
at /home/team/workspace/src/Network/HTTP/Affjax/Response.purs line 93, column 18 - line 93, column 28

  Could not match type

    Either

  with type

    ExceptT (NonEmptyList ForeignError)
```

I spent another 4 hours trying to fix this today, but I can't decipher what the error messages mean. Something needs to be Applicative, but isn't. I'll leave this here and hope a pro can pick it up.