### PR TITLE
make it work for electron

### DIFF
--- a/src/Network/HTTP/Affjax.js
+++ b/src/Network/HTTP/Affjax.js
@@ -1,6 +1,7 @@
 /* global exports */
 /* global XMLHttpRequest */
 /* global module */
+/* global process */
 "use strict";
 
 // module Network.HTTP.Affjax
@@ -8,7 +9,7 @@
 // jshint maxparams: 5
 exports._ajax = function (mkHeader, options, canceler, errback, callback) {
   var platformSpecific = { };
-  if (typeof module !== "undefined" && module.require) {
+  if (typeof module !== "undefined" && module.require && !(typeof process !== "undefined" && process.versions["electron"])) {
     // We are on node.js
     platformSpecific.newXHR = function () {
       var XHR = module.require("xhr2");


### PR DESCRIPTION
Hello,

Ajax does not work in electron because there is a `module` object in the scope. This PR fixes the problem. 

To detect running in electron, I referred https://github.com/electron/electron/issues/2288.