### PR TITLE
Updates for PureScript 0.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,21 +23,21 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-aff": "^2.0.1",
-    "purescript-argonaut-core": "^2.0.1",
-    "purescript-arraybuffer-types": "^0.2.0",
-    "purescript-dom": "^3.1.0",
-    "purescript-foreign": "^3.0.0",
-    "purescript-form-urlencoded": "^2.0.0",
-    "purescript-http-methods": "^2.0.0",
-    "purescript-integers": "^2.0.0",
+    "purescript-aff": "^3.0.0",
+    "purescript-argonaut-core": "^3.0.0",
+    "purescript-arraybuffer-types": "^1.0.0",
+    "purescript-dom": "^4.0.0",
+    "purescript-foreign": "^4.0.0",
+    "purescript-form-urlencoded": "^3.0.0",
+    "purescript-http-methods": "^3.0.0",
+    "purescript-integers": "^3.0.0",
     "purescript-math": "^2.0.0",
-    "purescript-media-types": "^2.0.0",
-    "purescript-nullable": "^2.0.0",
-    "purescript-refs": "^2.0.0",
-    "purescript-unsafe-coerce": "^2.0.0"
+    "purescript-media-types": "^3.0.0",
+    "purescript-nullable": "^3.0.0",
+    "purescript-refs": "^3.0.0",
+    "purescript-unsafe-coerce": "^3.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^2.0.0"
+    "purescript-console": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "eslint": "^3.10.1",
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
-    "pulp": "^9.0.1",
-    "purescript-psa": "^0.3.9",
-    "purescript": "^0.10.2",
+    "pulp": "^11.0.0",
+    "purescript-psa": "^0.5.0",
+    "purescript": "^0.11.0",
     "rimraf": "^2.5.4",
     "xhr2": "^0.1.3"
   }

--- a/src/Network/HTTP/Affjax.js
+++ b/src/Network/HTTP/Affjax.js
@@ -88,11 +88,3 @@ exports._cancelAjax = function (xhr, cancelError, errback, callback) {
   };
 };
 
-// jshint maxparams: 3
-exports._parseJSONImpl = function (left, right, str) {
-  try {
-    return right(JSON.parse(str));
-  } catch (e) {
-    return left(e.toString());
-  }
-};

--- a/src/Network/HTTP/Affjax.js
+++ b/src/Network/HTTP/Affjax.js
@@ -88,3 +88,11 @@ exports._cancelAjax = function (xhr, cancelError, errback, callback) {
   };
 };
 
+// jshint maxparams: 3
+exports._parseJSONImpl = function (left, right, str) {
+  try {
+    return right(JSON.parse(str));
+  } catch (e) {
+    return left(e.toString());
+  }
+};

--- a/src/Network/HTTP/Affjax.purs
+++ b/src/Network/HTTP/Affjax.purs
@@ -30,7 +30,7 @@ import DOM.XHR.Types (XMLHttpRequest)
 import Data.Argonaut.Parser (jsonParser)
 import Data.Either (Either(..), either)
 import Data.Foldable (any)
-import Data.Foreign (F, Foreign, ForeignError(..), fail, readString, toForeign)
+import Data.Foreign (F, Foreign, ForeignError(JSONError), fail, readString, toForeign)
 import Data.Function (on)
 import Data.Function.Uncurried (Fn5, runFn5, Fn4, runFn4)
 import Data.HTTP.Method (Method(..), CustomMethod)
@@ -90,7 +90,7 @@ affjax :: forall e a b. Requestable a => Respondable b => AffjaxRequest a -> Aff
 affjax = makeAff' <<< affjax'
 
 -- | Makes a `GET` request to the specified URL.
-get :: forall e a. (Respondable a) => URL -> Affjax e a
+get :: forall e a. Respondable a => URL -> Affjax e a
 get u = affjax $ defaultRequest { url = u }
 
 -- | Makes a `POST` request to the specified URL, sending data.
@@ -103,12 +103,12 @@ post' u c = affjax $ defaultRequest { method = Left POST, url = u, content = c }
 
 -- | Makes a `POST` request to the specified URL, sending data and ignoring the
 -- | response.
-post_ :: forall e a. (Requestable a) => URL -> a -> Affjax e Unit
+post_ :: forall e a. Requestable a => URL -> a -> Affjax e Unit
 post_ = post
 
 -- | Makes a `POST` request to the specified URL with the option to send data,
 -- | and ignores the response.
-post_' :: forall e a. (Requestable a) => URL -> Maybe a -> Affjax e Unit
+post_' :: forall e a. Requestable a => URL -> Maybe a -> Affjax e Unit
 post_' = post'
 
 -- | Makes a `PUT` request to the specified URL, sending data.
@@ -121,16 +121,16 @@ put' u c = affjax $ defaultRequest { method = Left PUT, url = u, content = c }
 
 -- | Makes a `PUT` request to the specified URL, sending data and ignoring the
 -- | response.
-put_ :: forall e a. (Requestable a) => URL -> a -> Affjax e Unit
+put_ :: forall e a. Requestable a => URL -> a -> Affjax e Unit
 put_ = put
 
 -- | Makes a `PUT` request to the specified URL with the option to send data,
 -- | and ignores the response.
-put_' :: forall e a. (Requestable a) => URL -> Maybe a -> Affjax e Unit
+put_' :: forall e a. Requestable a => URL -> Maybe a -> Affjax e Unit
 put_' = put'
 
 -- | Makes a `DELETE` request to the specified URL.
-delete :: forall e a. (Respondable a) => URL -> Affjax e a
+delete :: forall e a. Respondable a => URL -> Affjax e a
 delete u = affjax $ defaultRequest { method = Left DELETE, url = u }
 
 -- | Makes a `DELETE` request to the specified URL and ignores the response.
@@ -147,12 +147,12 @@ patch' u c = affjax $ defaultRequest { method = Left PATCH, url = u, content = c
 
 -- | Makes a `PATCH` request to the specified URL, sending data and ignoring the
 -- | response.
-patch_ :: forall e a. (Requestable a) => URL -> a -> Affjax e Unit
+patch_ :: forall e a. Requestable a => URL -> a -> Affjax e Unit
 patch_ = patch
 
 -- | Makes a `PATCH` request to the specified URL with the option to send data,
 -- | and ignores the response.
-patch_' :: forall e a. (Requestable a) => URL -> Maybe a -> Affjax e Unit
+patch_' :: forall e a. Requestable a => URL -> Maybe a -> Affjax e Unit
 patch_' = patch'
 
 -- | A sequence of retry delays, in milliseconds.
@@ -179,7 +179,7 @@ type RetryState e a = Either (Either e a) a
 -- | Retry a request using a `RetryPolicy`. After the timeout, the last received response is returned; if it was not possible to communicate with the server due to an error, then this is bubbled up.
 retry
   :: forall e a b
-   . (Requestable a)
+   . Requestable a
   => RetryPolicy
   -> (AffjaxRequest a -> Affjax (avar :: AVAR, ref :: REF | e) b)
   -> (AffjaxRequest a -> Affjax (avar :: AVAR, ref :: REF | e) b)
@@ -231,7 +231,8 @@ retry policy run req = do
 -- | Run a request directly without using `Aff`.
 affjax'
   :: forall e a b
-   . Requestable a => Respondable b
+   . Requestable a
+  => Respondable b
   => AffjaxRequest a
   -> (Error -> Eff (ajax :: AJAX | e) Unit)
   -> (AffjaxResponse b -> Eff (ajax :: AJAX | e) Unit)

--- a/src/Network/HTTP/Affjax.purs
+++ b/src/Network/HTTP/Affjax.purs
@@ -27,11 +27,12 @@ import Control.Monad.Eff.Exception (Error, error)
 import Control.Monad.Eff.Ref (REF, newRef, readRef, writeRef)
 import Control.Monad.Except (runExcept, throwError)
 import DOM.XHR.Types (XMLHttpRequest)
+import Data.Argonaut.Parser (jsonParser)
 import Data.Either (Either(..), either)
 import Data.Foldable (any)
-import Data.Foreign (F, Foreign, ForeignError(..), fail, readString)
+import Data.Foreign (F, Foreign, ForeignError(..), fail, readString, toForeign)
 import Data.Function (on)
-import Data.Function.Uncurried (Fn5, runFn5, Fn4, runFn4, Fn3, runFn3)
+import Data.Function.Uncurried (Fn5, runFn5, Fn4, runFn4)
 import Data.HTTP.Method (Method(..), CustomMethod)
 import Data.Int (toNumber)
 import Data.Maybe (Maybe(..))
@@ -276,7 +277,7 @@ affjax' req eb cb =
     Right res' -> cb res'
 
   parseJSON :: String -> F Foreign
-  parseJSON json = runFn3 _parseJSONImpl (fail <<< JSONError) pure json
+  parseJSON = either (fail <<< JSONError) (pure <<< toForeign) <<< jsonParser
 
   fromResponse' :: ResponseContent -> F b
   fromResponse' = case snd responseSettings of
@@ -311,6 +312,3 @@ foreign import _cancelAjax
                    (Error -> Eff (ajax :: AJAX | e) Unit)
                    (Boolean -> Eff (ajax :: AJAX | e) Unit)
                    (Eff (ajax :: AJAX | e) Unit)
-
-foreign import _parseJSONImpl
-  :: forall r. Fn3 (String -> r) (Foreign -> r) String r

--- a/src/Network/HTTP/Affjax.purs
+++ b/src/Network/HTTP/Affjax.purs
@@ -17,8 +17,8 @@ module Network.HTTP.Affjax
   , retry
   ) where
 
-import Data.Array as Arr
-import Data.HTTP.Method as Method
+import Prelude hiding (max)
+
 import Control.Monad.Aff (Aff, makeAff, makeAff', Canceler(..), attempt, delay, forkAff, cancel)
 import Control.Monad.Aff.AVar (AVAR, makeVar, takeVar, putVar)
 import Control.Monad.Eff (kind Effect, Eff)
@@ -26,27 +26,32 @@ import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Exception (Error, error)
 import Control.Monad.Eff.Ref (REF, newRef, readRef, writeRef)
 import Control.Monad.Except (runExcept, throwError)
-import DOM.XHR.Types (XMLHttpRequest)
+
 import Data.Argonaut.Parser (jsonParser)
+import Data.Array as Arr
 import Data.Either (Either(..), either)
 import Data.Foldable (any)
 import Data.Foreign (F, Foreign, ForeignError(JSONError), fail, readString, toForeign)
 import Data.Function (on)
 import Data.Function.Uncurried (Fn5, runFn5, Fn4, runFn4)
 import Data.HTTP.Method (Method(..), CustomMethod)
+import Data.HTTP.Method as Method
 import Data.Int (toNumber)
 import Data.Maybe (Maybe(..))
 import Data.MediaType (MediaType)
 import Data.Nullable (Nullable, toNullable)
 import Data.Time.Duration (Milliseconds(..))
 import Data.Tuple (Tuple(..), fst, snd)
+
 import Math (max, pow)
+
+import DOM.XHR.Types (XMLHttpRequest)
+
 import Network.HTTP.Affjax.Request (class Requestable, RequestContent, toRequest)
 import Network.HTTP.Affjax.Response (class Respondable, ResponseContent, ResponseType(..), fromResponse, responseType, responseTypeToString)
 import Network.HTTP.RequestHeader (RequestHeader(..), requestHeaderName, requestHeaderValue)
 import Network.HTTP.ResponseHeader (ResponseHeader, responseHeader)
 import Network.HTTP.StatusCode (StatusCode(..))
-import Prelude hiding (max)
 
 -- | The effect type for AJAX requests made with Affjax.
 foreign import data AJAX :: Effect

--- a/src/Network/HTTP/Affjax/Request.purs
+++ b/src/Network/HTTP/Affjax/Request.purs
@@ -22,7 +22,7 @@ import Unsafe.Coerce as U
 
 -- | Type representing all content types that be sent via XHR (ArrayBufferView,
 -- | Blob, Document, String, FormData).
-foreign import data RequestContent :: *
+foreign import data RequestContent :: Type
 
 -- | A class for types that can be converted to values that can be sent with
 -- | XHR requests. An optional mime-type can be specified for a default


### PR DESCRIPTION
I've been working on updating some packages for PureScript 0.11. I've bumped the dependency versions, updated the syntax, and dealt with API changes in the dependencies. (Control.Monad.Aff.delay instead of later', removal of parseJSON from Data.Foreign, etc.) The only public-facing API change is changing Int to Milliseconds in RetryPolicy.

The syntax in the test has also been updated, but I was not able to successfully execute the test and I am not sure whether that is a local problem or something that needs to be fixed ...

Let me know if it looks good!