### PR TITLE
Remove `Requestable` and `Respondable` classes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,21 +23,21 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-aff": "^4.0.0",
-    "purescript-argonaut-core": "^3.0.0",
-    "purescript-arraybuffer-types": "^1.0.0",
-    "purescript-dom": "^4.0.0",
-    "purescript-foreign": "^4.0.0",
-    "purescript-form-urlencoded": "^3.0.0",
-    "purescript-http-methods": "^3.0.0",
-    "purescript-integers": "^3.0.0",
-    "purescript-math": "^2.0.0",
-    "purescript-media-types": "^3.0.0",
-    "purescript-nullable": "^3.0.0",
-    "purescript-refs": "^3.0.0",
-    "purescript-unsafe-coerce": "^3.0.0"
+    "purescript-aff": "^5.0.0",
+    "purescript-argonaut-core": "^4.0.0",
+    "purescript-arraybuffer-types": "^2.0.0",
+    "purescript-web-xhr": "^2.0.0",
+    "purescript-foreign": "^5.0.0",
+    "purescript-form-urlencoded": "^4.0.0",
+    "purescript-http-methods": "^4.0.0",
+    "purescript-integers": "^4.0.0",
+    "purescript-math": "^2.1.1",
+    "purescript-media-types": "^4.0.0",
+    "purescript-nullable": "^4.0.0",
+    "purescript-refs": "^4.1.0",
+    "purescript-unsafe-coerce": "^4.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^3.0.0"
+    "purescript-console": "^4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "express": "^4.14.0",
     "pulp": "^11.0.0",
     "purescript-psa": "^0.5.0",
-    "purescript": "^0.11.0",
+    "purescript": "slamdata/node-purescript#0.12",
     "rimraf": "^2.5.4",
     "xhr2": "^0.1.3"
   }

--- a/src/Network/HTTP/Affjax.purs
+++ b/src/Network/HTTP/Affjax.purs
@@ -1,7 +1,7 @@
 module Network.HTTP.Affjax
   ( Affjax
   , AffjaxRequest, defaultRequest
-  , AffjaxResponseT
+  , AffjaxResponse
   , URL
   , affjax
   , get
@@ -13,7 +13,6 @@ module Network.HTTP.Affjax
   , RetryPolicy(..)
   , defaultRetryPolicy
   , retry
-  , module Exports
   ) where
 
 import Prelude
@@ -42,21 +41,20 @@ import Effect.Exception (Error, error)
 import Effect.Ref as Ref
 import Foreign (F, Foreign, ForeignError(..), fail, unsafeReadTagged, unsafeToForeign)
 import Math as Math
-import Network.HTTP.Affjax.Request (RequestContent(..), defaultMediaType)
-import Network.HTTP.Affjax.Request (RequestContent(..)) as Exports
-import Network.HTTP.Affjax.Response (AffjaxResponse(..), responseTypeToMediaType, responseTypeToString)
+import Network.HTTP.Affjax.Request as Request
+import Network.HTTP.Affjax.Response as Response
 import Network.HTTP.RequestHeader (RequestHeader(..), requestHeaderName, requestHeaderValue)
 import Network.HTTP.ResponseHeader (ResponseHeader, responseHeader)
 import Network.HTTP.StatusCode (StatusCode(..))
 
 -- | The result type for Affjax requests.
-type Affjax a = Aff (AffjaxResponseT a)
+type Affjax a = Aff (AffjaxResponse a)
 
 type AffjaxRequest =
   { method :: Either Method CustomMethod
   , url :: URL
   , headers :: Array RequestHeader
-  , content :: Maybe RequestContent
+  , content :: Maybe Request.Request
   , username :: Maybe String
   , password :: Maybe String
   , withCredentials :: Boolean
@@ -74,7 +72,7 @@ defaultRequest =
   }
 
 -- | The type of records that will be received as an Affjax response.
-type AffjaxResponseT a =
+type AffjaxResponse a =
   { status :: StatusCode
   , headers :: Array ResponseHeader
   , response :: a
@@ -84,70 +82,70 @@ type AffjaxResponseT a =
 type URL = String
 
 -- | Makes a `GET` request to the specified URL.
-get :: forall a. AffjaxResponse a -> URL -> Affjax a
+get :: forall a. Response.Response a -> URL -> Affjax a
 get rt u = affjax rt $ defaultRequest { url = u }
 
 -- | Makes a `POST` request to the specified URL, sending data.
-post :: forall a. AffjaxResponse a -> URL -> RequestContent -> Affjax a
+post :: forall a. Response.Response a -> URL -> Request.Request -> Affjax a
 post rt u c = affjax rt $ defaultRequest { method = Left POST, url = u, content = Just c }
 
 -- | Makes a `POST` request to the specified URL with the option to send data.
-post' :: forall a. AffjaxResponse a -> URL -> Maybe RequestContent -> Affjax a
+post' :: forall a. Response.Response a -> URL -> Maybe Request.Request -> Affjax a
 post' rt u c = affjax rt $ defaultRequest { method = Left POST, url = u, content = c }
 
 -- | Makes a `POST` request to the specified URL, sending data and ignoring the
 -- | response.
-post_ :: URL -> RequestContent -> Affjax Unit
-post_ = post (IgnoredResponse identity)
+post_ :: URL -> Request.Request -> Affjax Unit
+post_ = post Response.ignore
 
 -- | Makes a `POST` request to the specified URL with the option to send data,
 -- | and ignores the response.
-post_' :: URL -> Maybe RequestContent -> Affjax Unit
-post_' = post' (IgnoredResponse identity)
+post_' :: URL -> Maybe Request.Request -> Affjax Unit
+post_' = post' Response.ignore
 
 -- | Makes a `PUT` request to the specified URL, sending data.
-put :: forall a. AffjaxResponse a -> URL -> RequestContent -> Affjax a
+put :: forall a. Response.Response a -> URL -> Request.Request -> Affjax a
 put rt u c = affjax rt $ defaultRequest { method = Left PUT, url = u, content = Just c }
 
 -- | Makes a `PUT` request to the specified URL with the option to send data.
-put' :: forall a. AffjaxResponse a -> URL -> Maybe RequestContent -> Affjax a
+put' :: forall a. Response.Response a -> URL -> Maybe Request.Request -> Affjax a
 put' rt u c = affjax rt $ defaultRequest { method = Left PUT, url = u, content = c }
 
 -- | Makes a `PUT` request to the specified URL, sending data and ignoring the
 -- | response.
-put_ :: URL -> RequestContent -> Affjax Unit
-put_ = put  (IgnoredResponse identity)
+put_ :: URL -> Request.Request -> Affjax Unit
+put_ = put  Response.ignore
 
 -- | Makes a `PUT` request to the specified URL with the option to send data,
 -- | and ignores the response.
-put_' :: URL -> Maybe RequestContent -> Affjax Unit
-put_' = put'  (IgnoredResponse identity)
+put_' :: URL -> Maybe Request.Request -> Affjax Unit
+put_' = put'  Response.ignore
 
 -- | Makes a `DELETE` request to the specified URL.
-delete :: forall a. AffjaxResponse a -> URL -> Affjax a
+delete :: forall a. Response.Response a -> URL -> Affjax a
 delete rt u = affjax rt $ defaultRequest { method = Left DELETE, url = u }
 
 -- | Makes a `DELETE` request to the specified URL and ignores the response.
 delete_ :: URL -> Affjax Unit
-delete_ = delete (IgnoredResponse identity)
+delete_ = delete Response.ignore
 
 -- | Makes a `PATCH` request to the specified URL, sending data.
-patch :: forall a. AffjaxResponse a -> URL -> RequestContent -> Affjax a
+patch :: forall a. Response.Response a -> URL -> Request.Request -> Affjax a
 patch rt u c = affjax rt $ defaultRequest { method = Left PATCH, url = u, content = Just c }
 
 -- | Makes a `PATCH` request to the specified URL with the option to send data.
-patch' :: forall a. AffjaxResponse a -> URL -> Maybe RequestContent -> Affjax a
+patch' :: forall a. Response.Response a -> URL -> Maybe Request.Request -> Affjax a
 patch' rt u c = affjax rt $ defaultRequest { method = Left PATCH, url = u, content = c }
 
 -- | Makes a `PATCH` request to the specified URL, sending data and ignoring the
 -- | response.
-patch_ :: URL -> RequestContent -> Affjax Unit
-patch_ = patch (IgnoredResponse identity)
+patch_ :: URL -> Request.Request -> Affjax Unit
+patch_ = patch Response.ignore
 
 -- | Makes a `PATCH` request to the specified URL with the option to send data,
 -- | and ignores the response.
-patch_' :: URL -> Maybe RequestContent -> Affjax Unit
-patch_' = patch' (IgnoredResponse identity)
+patch_' :: URL -> Maybe Request.Request -> Affjax Unit
+patch_' = patch' Response.ignore
 
 -- | A sequence of retry delays, in milliseconds.
 type RetryDelayCurve = Int -> Milliseconds
@@ -189,8 +187,8 @@ retry policy run req = do
         Just resp -> pure resp
   where
     retryState
-      :: Either Error (AffjaxResponseT a)
-      -> RetryState Error (AffjaxResponseT a)
+      :: Either Error (AffjaxResponse a)
+      -> RetryState Error (AffjaxResponse a)
     retryState (Left exn) = Left $ Left exn
     retryState (Right resp) =
       case resp.status of
@@ -211,7 +209,7 @@ retry policy run req = do
         Right resp -> pure resp
 
 -- | Makes an `Affjax` request.
-affjax :: forall a. AffjaxResponse a -> AffjaxRequest -> Affjax a
+affjax :: forall a. Response.Response a -> AffjaxRequest -> Affjax a
 affjax rt req = do
   res <- AC.fromEffectFnAff $ runFn2 _ajax responseHeader req'
   case runExcept (fromResponse' res.response) of
@@ -225,26 +223,26 @@ affjax rt req = do
     , url: req.url
     , headers: (\h -> { field: requestHeaderName h, value: requestHeaderValue h }) <$> headers req.content
     , content: toNullable (extractContent <$> req.content)
-    , responseType: responseTypeToString rt
+    , responseType: Response.toResponseType rt
     , username: toNullable req.username
     , password: toNullable req.password
     , withCredentials: req.withCredentials
     }
 
-  extractContent :: RequestContent -> Foreign
+  extractContent :: Request.Request -> Foreign
   extractContent = case _ of
-    ArrayView f → f unsafeToForeign
-    BlobRequest x → unsafeToForeign x
-    DocumentRequest x → unsafeToForeign x
-    StringRequest x → unsafeToForeign x
-    FormDataRequest x → unsafeToForeign x
-    FormURLEncodedRequest x → unsafeToForeign (FormURLEncoded.encode x)
-    JsonRequest x → unsafeToForeign (J.stringify x)
+    Request.ArrayView f → f unsafeToForeign
+    Request.Blob x → unsafeToForeign x
+    Request.Document x → unsafeToForeign x
+    Request.String x → unsafeToForeign x
+    Request.FormData x → unsafeToForeign x
+    Request.FormURLEncoded x → unsafeToForeign (FormURLEncoded.encode x)
+    Request.Json x → unsafeToForeign (J.stringify x)
 
-  headers :: Maybe RequestContent -> Array RequestHeader
+  headers :: Maybe Request.Request -> Array RequestHeader
   headers reqContent =
-    addHeader (ContentType <$> (defaultMediaType =<< reqContent)) $
-      addHeader (Accept <$> responseTypeToMediaType rt)
+    addHeader (ContentType <$> (Request.toMediaType =<< reqContent)) $
+      addHeader (Accept <$> Response.toMediaType rt)
         req.headers
 
   addHeader :: Maybe RequestHeader -> Array RequestHeader -> Array RequestHeader
@@ -256,13 +254,13 @@ affjax rt req = do
   parseJSON = either (fail <<< ForeignError) pure <<< jsonParser
 
   fromResponse' :: Foreign -> F a
-  fromResponse' rc = case rt of
-    ArrayBufferResponse coe -> unsafeReadTagged "ArrayBuffer" rc
-    BlobResponse coe -> unsafeReadTagged "Blob" rc
-    DocumentResponse coe -> unsafeReadTagged "Document" rc
-    JSONResponse coe -> coe $ parseJSON =<< unsafeReadTagged "String" rc
-    StringResponse coe -> unsafeReadTagged "String" rc
-    IgnoredResponse coe -> coe $ pure unit
+  fromResponse' = case rt of
+    Response.ArrayBuffer _ -> unsafeReadTagged "ArrayBuffer"
+    Response.Blob _ -> unsafeReadTagged "Blob"
+    Response.Document _ -> unsafeReadTagged "Document"
+    Response.Json coe -> coe <<< parseJSON <=< unsafeReadTagged "String"
+    Response.String _ -> unsafeReadTagged "String"
+    Response.Ignore coe -> const $ coe (pure unit)
 
 type AjaxRequest a =
   { method :: String
@@ -280,4 +278,4 @@ foreign import _ajax
    . Fn2
       (String -> String -> ResponseHeader)
       (AjaxRequest a)
-      (AC.EffectFnAff (AffjaxResponseT Foreign))
+      (AC.EffectFnAff (AffjaxResponse Foreign))

--- a/src/Network/HTTP/Affjax/Request.purs
+++ b/src/Network/HTTP/Affjax/Request.purs
@@ -1,86 +1,34 @@
-module Network.HTTP.Affjax.Request
-  ( RequestContent()
-  , class Requestable, toRequest
-  ) where
+module Network.HTTP.Affjax.Request where
 
-import Prelude
-
-import Data.Argonaut.Core (Json())
+import DOM.File.Types (Blob)
+import DOM.Node.Types (Document)
+import DOM.XHR.Types (FormData)
+import Data.Argonaut.Core (Json)
 import Data.ArrayBuffer.Types as A
-import Data.FormURLEncoded (FormURLEncoded())
-import Data.FormURLEncoded as URLEncoded
+import Data.FormURLEncoded (FormURLEncoded)
 import Data.Maybe (Maybe(..))
-import Data.MediaType (MediaType())
+import Data.MediaType (MediaType)
 import Data.MediaType.Common (applicationJSON, applicationFormURLEncoded)
-import Data.Tuple (Tuple(..))
 
-import DOM.File.Types (Blob())
-import DOM.Node.Types (Document())
-import DOM.XHR.Types (FormData())
+data RequestContent
+  = ArrayViewInt8Request (A.ArrayView A.Int8)
+  | ArrayViewInt16Request (A.ArrayView A.Int16)
+  | ArrayViewInt32Request (A.ArrayView A.Int32)
+  | ArrayViewUint8Request (A.ArrayView A.Uint8)
+  | ArrayViewUint16Request (A.ArrayView A.Uint16)
+  | ArrayViewUint32Request (A.ArrayView A.Uint32)
+  | ArrayViewUint8ClampedRequest (A.ArrayView A.Uint8Clamped)
+  | ArrayViewFloat32Request (A.ArrayView A.Float32)
+  | ArrayViewFloat64Request (A.ArrayView A.Float64)
+  | BlobRequest Blob
+  | DocumentRequest Document
+  | StringRequest String
+  | FormDataRequest FormData
+  | FormURLEncodedRequest FormURLEncoded
+  | JsonRequest Json
 
-import Unsafe.Coerce as U
-
--- | Type representing all content types that be sent via XHR (ArrayBufferView,
--- | Blob, Document, String, FormData).
-foreign import data RequestContent :: Type
-
--- | A class for types that can be converted to values that can be sent with
--- | XHR requests. An optional mime-type can be specified for a default
--- | `Content-Type` header.
-class Requestable a where
-  toRequest :: a -> Tuple (Maybe MediaType) RequestContent
-
-defaultToRequest :: forall a. a -> Tuple (Maybe MediaType) RequestContent
-defaultToRequest = Tuple Nothing <<< U.unsafeCoerce
-
-instance requestableRequestContent :: Requestable RequestContent where
-  toRequest = defaultToRequest
-
-instance requestableInt8Array :: Requestable (A.ArrayView A.Int8) where
-  toRequest = defaultToRequest
-
-instance requestableInt16Array :: Requestable (A.ArrayView A.Int16) where
-  toRequest = defaultToRequest
-
-instance requestableInt32Array :: Requestable (A.ArrayView A.Int32) where
-  toRequest = defaultToRequest
-
-instance requestableUint8Array :: Requestable (A.ArrayView A.Uint8) where
-  toRequest = defaultToRequest
-
-instance requestableUint16Array :: Requestable (A.ArrayView A.Uint16) where
-  toRequest = defaultToRequest
-
-instance requestableUint32Array :: Requestable (A.ArrayView A.Uint32) where
-  toRequest = defaultToRequest
-
-instance requestableUint8ClampedArray :: Requestable (A.ArrayView A.Uint8Clamped) where
-  toRequest = defaultToRequest
-
-instance requestableFloat32Array :: Requestable (A.ArrayView A.Float32) where
-  toRequest = defaultToRequest
-
-instance requestableFloat64Array :: Requestable (A.ArrayView A.Float64) where
-  toRequest = defaultToRequest
-
-instance requestableBlob :: Requestable Blob where
-  toRequest = defaultToRequest
-
-instance requestableDocument :: Requestable Document where
-  toRequest = defaultToRequest
-
-instance requestableString :: Requestable String where
-  toRequest = defaultToRequest
-
-instance requestableJson :: Requestable Json where
-  toRequest json = Tuple (Just applicationJSON) (U.unsafeCoerce (show json))
-
-instance requestableFormData :: Requestable FormData where
-  toRequest = defaultToRequest
-
-instance requestableFormURLEncoded :: Requestable FormURLEncoded where
-  toRequest form = Tuple (Just applicationFormURLEncoded)
-                         (U.unsafeCoerce (URLEncoded.encode form))
-
-instance requestableUnit :: Requestable Unit where
-  toRequest = defaultToRequest
+defaultMediaType :: RequestContent -> Maybe MediaType
+defaultMediaType = case _ of
+  FormURLEncodedRequest _ -> Just applicationFormURLEncoded
+  JsonRequest _ -> Just applicationJSON
+  _ -> Nothing

--- a/src/Network/HTTP/Affjax/Request.purs
+++ b/src/Network/HTTP/Affjax/Request.purs
@@ -10,20 +10,38 @@ import Web.DOM.Document (Document)
 import Web.File.Blob (Blob)
 import Web.XHR.FormData (FormData)
 
-data RequestContent
+data Request
   = ArrayView (forall r. (forall a. A.ArrayView a -> r) -> r)
-  | BlobRequest Blob
-  | DocumentRequest Document
-  | StringRequest String
-  | FormDataRequest FormData
-  | FormURLEncodedRequest FormURLEncoded
-  | JsonRequest Json
+  | Blob Blob
+  | Document Document
+  | String String
+  | FormData FormData
+  | FormURLEncoded FormURLEncoded
+  | Json Json
 
-arrayView :: forall a. A.ArrayView a -> RequestContent
+arrayView :: forall a. A.ArrayView a -> Request
 arrayView av = ArrayView \f -> f av
 
-defaultMediaType :: RequestContent -> Maybe MediaType
-defaultMediaType = case _ of
-  FormURLEncodedRequest _ -> Just applicationFormURLEncoded
-  JsonRequest _ -> Just applicationJSON
+blob :: Blob -> Request
+blob = Blob
+
+document :: Document -> Request
+document = Document
+
+string :: String -> Request
+string = String
+
+formData :: FormData -> Request
+formData = FormData
+
+formURLEncoded :: FormURLEncoded -> Request
+formURLEncoded = FormURLEncoded
+
+json :: Json -> Request
+json = Json
+
+toMediaType :: Request -> Maybe MediaType
+toMediaType = case _ of
+  FormURLEncoded _ -> Just applicationFormURLEncoded
+  Json _ -> Just applicationJSON
   _ -> Nothing

--- a/src/Network/HTTP/Affjax/Request.purs
+++ b/src/Network/HTTP/Affjax/Request.purs
@@ -1,31 +1,26 @@
 module Network.HTTP.Affjax.Request where
 
-import DOM.File.Types (Blob)
-import DOM.Node.Types (Document)
-import DOM.XHR.Types (FormData)
 import Data.Argonaut.Core (Json)
 import Data.ArrayBuffer.Types as A
 import Data.FormURLEncoded (FormURLEncoded)
 import Data.Maybe (Maybe(..))
 import Data.MediaType (MediaType)
 import Data.MediaType.Common (applicationJSON, applicationFormURLEncoded)
+import Web.DOM.Document (Document)
+import Web.File.Blob (Blob)
+import Web.XHR.FormData (FormData)
 
 data RequestContent
-  = ArrayViewInt8Request (A.ArrayView A.Int8)
-  | ArrayViewInt16Request (A.ArrayView A.Int16)
-  | ArrayViewInt32Request (A.ArrayView A.Int32)
-  | ArrayViewUint8Request (A.ArrayView A.Uint8)
-  | ArrayViewUint16Request (A.ArrayView A.Uint16)
-  | ArrayViewUint32Request (A.ArrayView A.Uint32)
-  | ArrayViewUint8ClampedRequest (A.ArrayView A.Uint8Clamped)
-  | ArrayViewFloat32Request (A.ArrayView A.Float32)
-  | ArrayViewFloat64Request (A.ArrayView A.Float64)
+  = ArrayView (forall r. (forall a. A.ArrayView a -> r) -> r)
   | BlobRequest Blob
   | DocumentRequest Document
   | StringRequest String
   | FormDataRequest FormData
   | FormURLEncodedRequest FormURLEncoded
   | JsonRequest Json
+
+arrayView :: forall a. A.ArrayView a -> RequestContent
+arrayView av = ArrayView \f -> f av
 
 defaultMediaType :: RequestContent -> Maybe MediaType
 defaultMediaType = case _ of

--- a/src/Network/HTTP/Affjax/Response.purs
+++ b/src/Network/HTTP/Affjax/Response.purs
@@ -10,44 +10,44 @@ import Data.MediaType.Common (applicationJSON)
 import Web.DOM.Document (Document)
 import Web.File.Blob (Blob)
 
-data AffjaxResponse a
-  = ArrayBufferResponse (forall f. f ArrayBuffer -> f a)
-  | BlobResponse (forall f. f Blob -> f a)
-  | DocumentResponse (forall f. f Document -> f a)
-  | JSONResponse (forall f. f Json -> f a)
-  | StringResponse (forall f. f String -> f a)
-  | IgnoredResponse (forall f. f Unit -> f a)
+data Response a
+  = ArrayBuffer (forall f. f ArrayBuffer -> f a)
+  | Blob (forall f. f Blob -> f a)
+  | Document (forall f. f Document -> f a)
+  | Json (forall f. f Json -> f a)
+  | String (forall f. f String -> f a)
+  | Ignore (forall f. f Unit -> f a)
 
-arrayBuffer :: AffjaxResponse ArrayBuffer
-arrayBuffer = ArrayBufferResponse identity
+arrayBuffer :: Response ArrayBuffer
+arrayBuffer = ArrayBuffer identity
 
-blob :: AffjaxResponse Blob
-blob = BlobResponse identity
+blob :: Response Blob
+blob = Blob identity
 
-document :: AffjaxResponse Document
-document = DocumentResponse identity
+document :: Response Document
+document = Document identity
 
-json :: AffjaxResponse Json
-json = JSONResponse identity
+json :: Response Json
+json = Json identity
 
-string :: AffjaxResponse String
-string = StringResponse identity
+string :: Response String
+string = String identity
 
-ignored :: AffjaxResponse Unit
-ignored = IgnoredResponse identity
+ignore :: Response Unit
+ignore = Ignore identity
 
-responseTypeToString :: forall a. AffjaxResponse a -> String
-responseTypeToString =
+toResponseType :: forall a. Response a -> String
+toResponseType =
   case _ of
-    ArrayBufferResponse _ -> "arraybuffer"
-    BlobResponse _ -> "blob"
-    DocumentResponse _ -> "document"
-    JSONResponse _ -> "text" -- IE doesn't support "json" responseType
-    StringResponse _ -> "text"
-    IgnoredResponse _ -> "text"
+    ArrayBuffer _ -> "arraybuffer"
+    Blob _ -> "blob"
+    Document _ -> "document"
+    Json _ -> "text" -- IE doesn't support "json" responseType
+    String _ -> "text"
+    Ignore _ -> ""
 
-responseTypeToMediaType :: forall a. AffjaxResponse a -> Maybe MediaType
-responseTypeToMediaType =
+toMediaType :: forall a. Response a -> Maybe MediaType
+toMediaType =
   case _ of
-    JSONResponse _ -> Just applicationJSON
+    Json _ -> Just applicationJSON
     _ -> Nothing

--- a/src/Network/HTTP/ResponseHeader.purs
+++ b/src/Network/HTTP/ResponseHeader.purs
@@ -6,11 +6,8 @@ module Network.HTTP.ResponseHeader
   ) where
 
 import Prelude
-import Data.Generic (class Generic)
 
 data ResponseHeader = ResponseHeader String String
-
-derive instance genericResponseHeader :: Generic ResponseHeader
 
 responseHeader :: String -> String -> ResponseHeader
 responseHeader field value = ResponseHeader field value

--- a/src/Network/HTTP/StatusCode.purs
+++ b/src/Network/HTTP/StatusCode.purs
@@ -1,11 +1,8 @@
 module Network.HTTP.StatusCode where
 
 import Prelude
-import Data.Generic (class Generic)
 
 newtype StatusCode = StatusCode Int
-
-derive instance genericStatusCode :: Generic StatusCode
 
 instance eqStatusCode :: Eq StatusCode where
   eq (StatusCode x) (StatusCode y) = x == y

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -93,13 +93,13 @@ main = void $ runAff (either (\e -> logShow e *> throwException e) (const $ log 
     assertEq ok200 res.status
 
   A.log "POST /mirror: should use the POST method"
-  (attempt $ AX.post mirror "test") >>= assertRight >>= \res -> do
+  (attempt $ AX.post mirror (AX.StringRequest "test")) >>= assertRight >>= \res -> do
     assertEq ok200 res.status
     assertEq "POST" (_.method $ unsafeFromForeign res.response)
 
   A.log "PUT with a request body"
   let content = "the quick brown fox jumps over the lazy dog"
-  (attempt $ AX.put mirror content) >>= assertRight >>= \res -> do
+  (attempt $ AX.put mirror (AX.StringRequest content)) >>= assertRight >>= \res -> do
     typeIs (res :: AX.AffjaxResponse Foreign)
     assertEq ok200 res.status
     let mirroredReq = unsafeFromForeign res.response
@@ -113,5 +113,5 @@ main = void $ runAff (either (\e -> logShow e *> throwException e) (const $ log 
     -- assertEq (Just "test=test") (lookupHeader "Set-Cookie" res.headers)
 
   A.log "Testing cancellation"
-  forkAff (AX.post_ mirror "do it now") >>= killFiber (error "Pull the cord!")
+  forkAff (AX.post_ mirror (AX.StringRequest "do it now")) >>= killFiber (error "Pull the cord!")
   assertMsg "Should have been canceled" true

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,114 +1,94 @@
 module Test.Main where
 
 import Prelude
-import Control.Monad.Aff.Console as A
-import Network.HTTP.Affjax as AX
-import Control.Monad.Aff (Aff, forkAff, attempt, runAff, killFiber)
-import Control.Monad.Aff.AVar (AVAR)
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Class (liftEff)
-import Control.Monad.Eff.Console (CONSOLE, log, logShow)
-import Control.Monad.Eff.Exception (EXCEPTION, error, throwException)
-import Control.Monad.Eff.Ref (REF)
+
 import Control.Monad.Error.Class (throwError)
+import Data.Argonaut.Core as J
 import Data.Either (Either(..), either)
-import Data.Foreign (Foreign, unsafeFromForeign)
 import Data.Maybe (Maybe(..))
 import Data.Time.Duration (Milliseconds(..))
+import Effect (Effect)
+import Effect.Aff (Aff, forkAff, attempt, runAff, killFiber)
+import Effect.Class (liftEffect)
+import Effect.Class.Console as A
+import Effect.Console (log, logShow)
+import Effect.Exception (error, throwException)
+import Foreign.Object as FO
+import Network.HTTP.Affjax as AX
+import Network.HTTP.Affjax.Response as AXR
 import Network.HTTP.StatusCode (StatusCode(..))
 
-foreign import logAny :: forall e a. a -> Eff (console :: CONSOLE | e) Unit
+foreign import logAny :: forall a. a -> Effect Unit
 
-logAny' :: forall e a. a -> Assert e Unit
-logAny' = liftEff <<< logAny
+logAny' :: forall a. a -> Aff Unit
+logAny' = liftEffect <<< logAny
 
-type Assert e a = Aff (exception :: EXCEPTION, console :: CONSOLE, ajax :: AX.AJAX | e) a
-
-assertFail :: forall e a. String -> Assert e a
+assertFail :: forall a. String -> Aff a
 assertFail = throwError <<< error
 
-assertMsg :: forall e. String -> Boolean -> Assert e Unit
+assertMsg :: String -> Boolean -> Aff Unit
 assertMsg _ true = pure unit
 assertMsg msg false = assertFail msg
 
-assertRight :: forall e a b. Either a b -> Assert e b
+assertRight :: forall a b. Either a b -> Aff b
 assertRight x = case x of
   Left y -> logAny' y >>= \_ -> assertFail "Expected a Right value"
   Right y -> pure y
 
-assertLeft :: forall e a b. Either a b -> Assert e a
+assertLeft :: forall a b. Either a b -> Aff a
 assertLeft x = case x of
   Right y -> logAny' y >>= \_ -> assertFail "Expected a Left value"
   Left y -> pure y
 
-assertEq :: forall e a. Eq a => Show a => a -> a -> Assert e Unit
+assertEq :: forall a. Eq a => Show a => a -> a -> Aff Unit
 assertEq x y =
   when (x /= y) $ assertFail $ "Expected " <> show x <> ", got " <> show y
 
--- | For helping type inference
-typeIs :: forall e a. a -> Assert e Unit
-typeIs = const (pure unit)
-
-type MainEffects e =
-  ( ref :: REF
-  , avar :: AVAR
-  , exception :: EXCEPTION
-  , console :: CONSOLE
-  | e
-  )
-
-main :: Eff (MainEffects (ajax :: AX.AJAX)) Unit
+main :: Effect Unit
 main = void $ runAff (either (\e -> logShow e *> throwException e) (const $ log "affjax: All good!")) do
   let ok200 = StatusCode 200
   let notFound404 = StatusCode 404
 
   -- A complete URL is necessary for tests to work on Node.js
   let prefix = append "http://localhost:3838"
-  let mirror       = prefix "/mirror"
+  let mirror = prefix "/mirror"
   let doesNotExist = prefix "/does-not-exist"
-  let notJson      = prefix "/not-json"
+  let notJson = prefix "/not-json"
   let retryPolicy = AX.defaultRetryPolicy { timeout = Just (Milliseconds 500.0), shouldRetryWithStatusCode = \_ -> true }
 
   A.log "GET /does-not-exist: should be 404 Not found after retries"
-  (attempt $ AX.retry retryPolicy AX.affjax $ AX.defaultRequest { url = doesNotExist }) >>= assertRight >>= \res -> do
-    typeIs (res :: AX.AffjaxResponse String)
+  (attempt $ AX.retry retryPolicy (AX.affjax AXR.ignored) $ AX.defaultRequest { url = doesNotExist }) >>= assertRight >>= \res -> do
     assertEq notFound404 res.status
 
   A.log "GET /mirror: should be 200 OK"
-  (attempt $ AX.affjax $ AX.defaultRequest { url = mirror }) >>= assertRight >>= \res -> do
-    typeIs (res :: AX.AffjaxResponse Foreign)
+  (attempt $ AX.affjax AXR.ignored $ AX.defaultRequest { url = mirror }) >>= assertRight >>= \res -> do
     assertEq ok200 res.status
 
   A.log "GET /does-not-exist: should be 404 Not found"
-  (attempt $ AX.affjax $ AX.defaultRequest { url = doesNotExist }) >>= assertRight >>= \res -> do
-    typeIs (res :: AX.AffjaxResponse String)
+  (attempt $ AX.affjax AXR.ignored $ AX.defaultRequest { url = doesNotExist }) >>= assertRight >>= \res -> do
     assertEq notFound404 res.status
 
   A.log "GET /not-json: invalid JSON with Foreign response should throw an error"
-  void $ assertLeft =<< attempt (AX.get doesNotExist :: AX.Affjax (MainEffects ()) Foreign)
+  void $ assertLeft =<< attempt (AX.get AXR.json doesNotExist)
 
   A.log "GET /not-json: invalid JSON with String response should be ok"
-  (attempt $ AX.get notJson) >>= assertRight >>= \res -> do
-    typeIs (res :: AX.AffjaxResponse String)
+  (attempt $ AX.get AXR.string notJson) >>= assertRight >>= \res -> do
     assertEq ok200 res.status
 
   A.log "POST /mirror: should use the POST method"
-  (attempt $ AX.post mirror (AX.StringRequest "test")) >>= assertRight >>= \res -> do
+  (attempt $ AX.post AXR.json mirror (AX.StringRequest "test")) >>= assertRight >>= \res -> do
     assertEq ok200 res.status
-    assertEq "POST" (_.method $ unsafeFromForeign res.response)
+    assertEq (Just "POST") (J.toString =<< FO.lookup "method" =<< J.toObject res.response)
 
   A.log "PUT with a request body"
   let content = "the quick brown fox jumps over the lazy dog"
-  (attempt $ AX.put mirror (AX.StringRequest content)) >>= assertRight >>= \res -> do
-    typeIs (res :: AX.AffjaxResponse Foreign)
+  (attempt $ AX.put AXR.json mirror (AX.StringRequest content)) >>= assertRight >>= \res -> do
     assertEq ok200 res.status
-    let mirroredReq = unsafeFromForeign res.response
-    assertEq "PUT"   mirroredReq.method
-    assertEq content mirroredReq.body
+    assertEq (Just "PUT") (J.toString =<< FO.lookup "method" =<< J.toObject res.response)
+    assertEq (Just content) (J.toString =<< FO.lookup "body" =<< J.toObject res.response)
 
   A.log "Testing CORS, HTTPS"
-  (attempt $ AX.get "https://cors-test.appspot.com/test") >>= assertRight >>= \res -> do
-    typeIs (res :: AX.AffjaxResponse Foreign)
+  (attempt $ AX.get AXR.json "https://cors-test.appspot.com/test") >>= assertRight >>= \res -> do
     assertEq ok200 res.status
     -- assertEq (Just "test=test") (lookupHeader "Set-Cookie" res.headers)
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -15,7 +15,8 @@ import Effect.Console (log, logShow)
 import Effect.Exception (error, throwException)
 import Foreign.Object as FO
 import Network.HTTP.Affjax as AX
-import Network.HTTP.Affjax.Response as AXR
+import Network.HTTP.Affjax.Request as Request
+import Network.HTTP.Affjax.Response as Response
 import Network.HTTP.StatusCode (StatusCode(..))
 
 foreign import logAny :: forall a. a -> Effect Unit
@@ -57,41 +58,41 @@ main = void $ runAff (either (\e -> logShow e *> throwException e) (const $ log 
   let retryPolicy = AX.defaultRetryPolicy { timeout = Just (Milliseconds 500.0), shouldRetryWithStatusCode = \_ -> true }
 
   A.log "GET /does-not-exist: should be 404 Not found after retries"
-  (attempt $ AX.retry retryPolicy (AX.affjax AXR.ignored) $ AX.defaultRequest { url = doesNotExist }) >>= assertRight >>= \res -> do
+  (attempt $ AX.retry retryPolicy (AX.affjax Response.ignore) $ AX.defaultRequest { url = doesNotExist }) >>= assertRight >>= \res -> do
     assertEq notFound404 res.status
 
   A.log "GET /mirror: should be 200 OK"
-  (attempt $ AX.affjax AXR.ignored $ AX.defaultRequest { url = mirror }) >>= assertRight >>= \res -> do
+  (attempt $ AX.affjax Response.ignore $ AX.defaultRequest { url = mirror }) >>= assertRight >>= \res -> do
     assertEq ok200 res.status
 
   A.log "GET /does-not-exist: should be 404 Not found"
-  (attempt $ AX.affjax AXR.ignored $ AX.defaultRequest { url = doesNotExist }) >>= assertRight >>= \res -> do
+  (attempt $ AX.affjax Response.ignore $ AX.defaultRequest { url = doesNotExist }) >>= assertRight >>= \res -> do
     assertEq notFound404 res.status
 
   A.log "GET /not-json: invalid JSON with Foreign response should throw an error"
-  void $ assertLeft =<< attempt (AX.get AXR.json doesNotExist)
+  void $ assertLeft =<< attempt (AX.get Response.json doesNotExist)
 
   A.log "GET /not-json: invalid JSON with String response should be ok"
-  (attempt $ AX.get AXR.string notJson) >>= assertRight >>= \res -> do
+  (attempt $ AX.get Response.string notJson) >>= assertRight >>= \res -> do
     assertEq ok200 res.status
 
   A.log "POST /mirror: should use the POST method"
-  (attempt $ AX.post AXR.json mirror (AX.StringRequest "test")) >>= assertRight >>= \res -> do
+  (attempt $ AX.post Response.json mirror (Request.string "test")) >>= assertRight >>= \res -> do
     assertEq ok200 res.status
     assertEq (Just "POST") (J.toString =<< FO.lookup "method" =<< J.toObject res.response)
 
   A.log "PUT with a request body"
   let content = "the quick brown fox jumps over the lazy dog"
-  (attempt $ AX.put AXR.json mirror (AX.StringRequest content)) >>= assertRight >>= \res -> do
+  (attempt $ AX.put Response.json mirror (Request.string content)) >>= assertRight >>= \res -> do
     assertEq ok200 res.status
     assertEq (Just "PUT") (J.toString =<< FO.lookup "method" =<< J.toObject res.response)
     assertEq (Just content) (J.toString =<< FO.lookup "body" =<< J.toObject res.response)
 
   A.log "Testing CORS, HTTPS"
-  (attempt $ AX.get AXR.json "https://cors-test.appspot.com/test") >>= assertRight >>= \res -> do
+  (attempt $ AX.get Response.json "https://cors-test.appspot.com/test") >>= assertRight >>= \res -> do
     assertEq ok200 res.status
     -- assertEq (Just "test=test") (lookupHeader "Set-Cookie" res.headers)
 
   A.log "Testing cancellation"
-  forkAff (AX.post_ mirror (AX.StringRequest "do it now")) >>= killFiber (error "Pull the cord!")
+  forkAff (AX.post_ mirror (Request.string "do it now")) >>= killFiber (error "Pull the cord!")
   assertMsg "Should have been canceled" true


### PR DESCRIPTION
There's a slight hitch in removing `Respondable`, as when the request is made, the `responseType` param needs setting, which has an effect on how the XHR interprets the response. Currently we can do this as we know the intended response before it arrives, but if we switch to a sum it's not obvious how to work with it.

ping @natefaubion 