### PR TITLE
More descriptive names

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install xhr2
 
 ## Introduction
 
-You can construct requests with the `affjax` function:
+You can construct requests with the `request` function:
 
 ```purescript
 module Main where
@@ -35,10 +35,10 @@ import Effect.Aff (launchAff)
 import Effect.Class (liftEffect)
 import Effect.Console (log)
 import Network.HTTP.Affjax as AX
-import Network.HTTP.Affjax.Response as AXRes
+import Network.HTTP.Affjax.ResponseFormat as ResponseFormat
 
 main = launchAff $ do
-  res <- AX.affjax AXRes.json (AX.defaultRequest { url = "/api", method = Left GET })
+  res <- AX.request ResponseFormat.json (AX.defaultRequest { url = "/api", method = Left GET })
   liftEffect $ log $ "GET /api response: " <> J.stringify res.response
 ```
 
@@ -47,13 +47,13 @@ main = launchAff $ do
 Or use of a number of helpers for common cases:
 
 ```purescript
-import Network.HTTP.Affjax.Request as AXReq
+import Network.HTTP.Affjax.RequestBody as RequestBody
 
 main = launchAff $ do
-  res1 <- AX.get AXRes.json "/api"
+  res1 <- AX.get ResponseFormat.json "/api"
   liftEffect $ log $ "GET /api response: " <> J.stringify res1.response
 
-  res2 <- AX.post AXRes.json "/api" (AXReq.json (J.fromString "test"))
+  res2 <- AX.post ResponseFormat.json "/api" (RequestBody.json (J.fromString "test"))
   liftEffect $ log $ "POST /api response: " <> J.stringify res2.response
 ```
 

--- a/src/Network/HTTP/Affjax/RequestBody.purs
+++ b/src/Network/HTTP/Affjax/RequestBody.purs
@@ -1,4 +1,4 @@
-module Network.HTTP.Affjax.Request where
+module Network.HTTP.Affjax.RequestBody where
 
 import Data.Argonaut.Core (Json)
 import Data.ArrayBuffer.Types as A
@@ -12,7 +12,7 @@ import Web.XHR.FormData (FormData)
 
 -- | Represents data for an HTTP request that will be included in the request
 -- | body.
-data Request
+data RequestBody
   = ArrayView (forall r. (forall a. A.ArrayView a -> r) -> r)
   | Blob Blob
   | Document Document
@@ -21,28 +21,28 @@ data Request
   | FormURLEncoded FormURLEncoded
   | Json Json
 
-arrayView :: forall a. A.ArrayView a -> Request
+arrayView :: forall a. A.ArrayView a -> RequestBody
 arrayView av = ArrayView \f -> f av
 
-blob :: Blob -> Request
+blob :: Blob -> RequestBody
 blob = Blob
 
-document :: Document -> Request
+document :: Document -> RequestBody
 document = Document
 
-string :: String -> Request
+string :: String -> RequestBody
 string = String
 
-formData :: FormData -> Request
+formData :: FormData -> RequestBody
 formData = FormData
 
-formURLEncoded :: FormURLEncoded -> Request
+formURLEncoded :: FormURLEncoded -> RequestBody
 formURLEncoded = FormURLEncoded
 
-json :: Json -> Request
+json :: Json -> RequestBody
 json = Json
 
-toMediaType :: Request -> Maybe MediaType
+toMediaType :: RequestBody -> Maybe MediaType
 toMediaType = case _ of
   FormURLEncoded _ -> Just applicationFormURLEncoded
   Json _ -> Just applicationJSON

--- a/src/Network/HTTP/Affjax/ResponseFormat.purs
+++ b/src/Network/HTTP/Affjax/ResponseFormat.purs
@@ -1,4 +1,4 @@
-module Network.HTTP.Affjax.Response where
+module Network.HTTP.Affjax.ResponseFormat where
 
 import Prelude
 
@@ -11,7 +11,7 @@ import Web.DOM.Document (Document)
 import Web.File.Blob (Blob)
 
 -- | Used to represent how a HTTP response body should be interpreted.
-data Response a
+data ResponseFormat a
   = ArrayBuffer (forall f. f ArrayBuffer -> f a)
   | Blob (forall f. f Blob -> f a)
   | Document (forall f. f Document -> f a)
@@ -19,37 +19,37 @@ data Response a
   | String (forall f. f String -> f a)
   | Ignore (forall f. f Unit -> f a)
 
-arrayBuffer :: Response ArrayBuffer
+arrayBuffer :: ResponseFormat ArrayBuffer
 arrayBuffer = ArrayBuffer identity
 
-blob :: Response Blob
+blob :: ResponseFormat Blob
 blob = Blob identity
 
-document :: Response Document
+document :: ResponseFormat Document
 document = Document identity
 
-json :: Response Json
+json :: ResponseFormat Json
 json = Json identity
 
-string :: Response String
+string :: ResponseFormat String
 string = String identity
 
-ignore :: Response Unit
+ignore :: ResponseFormat Unit
 ignore = Ignore identity
 
 -- | Converts a `Response a` into a string representation of the response type
 -- | that it represents.
-toResponseType :: forall a. Response a -> String
+toResponseType :: forall a. ResponseFormat a -> String
 toResponseType =
   case _ of
     ArrayBuffer _ -> "arraybuffer"
     Blob _ -> "blob"
     Document _ -> "document"
-    Json _ -> "text" -- IE doesn't support "json" responseType
+    Json _ -> "text" -- IE doesn't support "json" ResponseFormat
     String _ -> "text"
     Ignore _ -> ""
 
-toMediaType :: forall a. Response a -> Maybe MediaType
+toMediaType :: forall a. ResponseFormat a -> Maybe MediaType
 toMediaType =
   case _ of
     Json _ -> Just applicationJSON

--- a/test/DocExamples.purs
+++ b/test/DocExamples.purs
@@ -9,16 +9,16 @@ import Effect.Aff (launchAff)
 import Effect.Class (liftEffect)
 import Effect.Console (log)
 import Network.HTTP.Affjax as AX
-import Network.HTTP.Affjax.Request as AXReq
-import Network.HTTP.Affjax.Response as AXRes
+import Network.HTTP.Affjax.RequestBody as RequestBody
+import Network.HTTP.Affjax.ResponseFormat as ResponseFormat
 
 main = launchAff $ do
-  res <- AX.affjax AXRes.json (AX.defaultRequest { url = "/api", method = Left GET })
+  res <- AX.request ResponseFormat.json (AX.defaultRequest { url = "/api", method = Left GET })
   liftEffect $ log $ "GET /api response: " <> J.stringify res.response
 
 main' = launchAff $ do
-  res1 <- AX.get AXRes.json "/api"
+  res1 <- AX.get ResponseFormat.json "/api"
   liftEffect $ log $ "GET /api response: " <> J.stringify res1.response
 
-  res2 <- AX.post AXRes.json "/api" (AXReq.json (J.fromString "test"))
+  res2 <- AX.post ResponseFormat.json "/api" (RequestBody.json (J.fromString "test"))
   liftEffect $ log $ "POST /api response: " <> J.stringify res2.response

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -15,8 +15,8 @@ import Effect.Console (log, logShow)
 import Effect.Exception (error, throwException)
 import Foreign.Object as FO
 import Network.HTTP.Affjax as AX
-import Network.HTTP.Affjax.Request as Request
-import Network.HTTP.Affjax.Response as Response
+import Network.HTTP.Affjax.RequestBody as RequestBody
+import Network.HTTP.Affjax.ResponseFormat as ResponseFormat
 import Network.HTTP.StatusCode (StatusCode(..))
 
 foreign import logAny :: forall a. a -> Effect Unit
@@ -58,41 +58,41 @@ main = void $ runAff (either (\e -> logShow e *> throwException e) (const $ log 
   let retryPolicy = AX.defaultRetryPolicy { timeout = Just (Milliseconds 500.0), shouldRetryWithStatusCode = \_ -> true }
 
   A.log "GET /does-not-exist: should be 404 Not found after retries"
-  (attempt $ AX.retry retryPolicy (AX.affjax Response.ignore) $ AX.defaultRequest { url = doesNotExist }) >>= assertRight >>= \res -> do
+  (attempt $ AX.retry retryPolicy (AX.request ResponseFormat.ignore) $ AX.defaultRequest { url = doesNotExist }) >>= assertRight >>= \res -> do
     assertEq notFound404 res.status
 
   A.log "GET /mirror: should be 200 OK"
-  (attempt $ AX.affjax Response.ignore $ AX.defaultRequest { url = mirror }) >>= assertRight >>= \res -> do
+  (attempt $ AX.request ResponseFormat.ignore $ AX.defaultRequest { url = mirror }) >>= assertRight >>= \res -> do
     assertEq ok200 res.status
 
   A.log "GET /does-not-exist: should be 404 Not found"
-  (attempt $ AX.affjax Response.ignore $ AX.defaultRequest { url = doesNotExist }) >>= assertRight >>= \res -> do
+  (attempt $ AX.request ResponseFormat.ignore $ AX.defaultRequest { url = doesNotExist }) >>= assertRight >>= \res -> do
     assertEq notFound404 res.status
 
   A.log "GET /not-json: invalid JSON with Foreign response should throw an error"
-  void $ assertLeft =<< attempt (AX.get Response.json doesNotExist)
+  void $ assertLeft =<< attempt (AX.get ResponseFormat.json doesNotExist)
 
   A.log "GET /not-json: invalid JSON with String response should be ok"
-  (attempt $ AX.get Response.string notJson) >>= assertRight >>= \res -> do
+  (attempt $ AX.get ResponseFormat.string notJson) >>= assertRight >>= \res -> do
     assertEq ok200 res.status
 
   A.log "POST /mirror: should use the POST method"
-  (attempt $ AX.post Response.json mirror (Request.string "test")) >>= assertRight >>= \res -> do
+  (attempt $ AX.post ResponseFormat.json mirror (RequestBody.string "test")) >>= assertRight >>= \res -> do
     assertEq ok200 res.status
     assertEq (Just "POST") (J.toString =<< FO.lookup "method" =<< J.toObject res.response)
 
   A.log "PUT with a request body"
   let content = "the quick brown fox jumps over the lazy dog"
-  (attempt $ AX.put Response.json mirror (Request.string content)) >>= assertRight >>= \res -> do
+  (attempt $ AX.put ResponseFormat.json mirror (RequestBody.string content)) >>= assertRight >>= \res -> do
     assertEq ok200 res.status
     assertEq (Just "PUT") (J.toString =<< FO.lookup "method" =<< J.toObject res.response)
     assertEq (Just content) (J.toString =<< FO.lookup "body" =<< J.toObject res.response)
 
   A.log "Testing CORS, HTTPS"
-  (attempt $ AX.get Response.json "https://cors-test.appspot.com/test") >>= assertRight >>= \res -> do
+  (attempt $ AX.get ResponseFormat.json "https://cors-test.appspot.com/test") >>= assertRight >>= \res -> do
     assertEq ok200 res.status
     -- assertEq (Just "test=test") (lookupHeader "Set-Cookie" res.headers)
 
   A.log "Testing cancellation"
-  forkAff (AX.post_ mirror (Request.string "do it now")) >>= killFiber (error "Pull the cord!")
+  forkAff (AX.post_ mirror (RequestBody.string "do it now")) >>= killFiber (error "Pull the cord!")
   assertMsg "Should have been canceled" true


### PR DESCRIPTION
As a newcomer to Affjax, I found the names of the various types and functions to be a bit confusing.  As an example of what I found confusing, there is a type named `Response` _and_ a typed named `AffjaxResponse`. They sound like the same thing. Furthermore, `Response` isn't actually a response. It's a description of how to interpret the body of a response.

In this PR I've tried to rename things in ways that, at least to me, makes more sense. Obviously naming is somewhat of an opinion. But, below is a list of the things that the PR renames with my rationale for the renaming.

* `Response` to `ResponseFormat`. This type isn't actually a response. It's a description about which format the body of a response should be interpreted as.
* `AffjaxResponse` to `Response`. This is the actual type of a response.
* `Request` to `RequestBody`. This type is not a request but the type of things that can be used as the body of a request.
* `AffjaxRequest` to `RequestOptions`. This type represents a record of options specifying how a request should be made.
* `affjax` to `request`. The name "affjax" doesn't really communicate anything. The name `request` is appropriate since this is the function used to make requests.
* `Affjax` removed. `Affjax a` is equivalent to `Aff (Response a)`. IMO the `Affjax` type only obfuscated the types and made it harder to see that the functions in the library return responses in the `Aff` monad.

As an example this is the type of `post` today:

```haskell
post :: forall a. Response a -> URL -> Request -> Affjax a
```

And this is the type of `post` in this PR:

```haskell
post :: forall a. ResponseFormat a -> URL -> RequestBody -> Aff (Response a)
```

I'd argue the latter is easier to understand. I find it confusing that the first argument has the type `Response`. Why do I need to give a response to a function that is supposed to make a request and return a response? Also, the name `RequestBody` makes it explicit which argument is the actual payload for the request.