### PR TITLE
Fix the script got stuck when request timed out

### DIFF
--- a/src/Affjax.js
+++ b/src/Affjax.js
@@ -53,9 +53,13 @@ exports._ajax = function () {
           errback(e);
         }
       }
-      xhr.onerror = function () {
-        errback(new Error("AJAX request failed: " + options.method + " " + options.url));
+      var onerror = function (msg) {
+        return function () {
+          errback(new Error(msg + ": " + options.method + " " + options.url));
+        };
       };
+      xhr.onerror = onerror("AJAX request failed");
+      xhr.ontimeout = onerror("AJAX request timed out");
       xhr.onload = function () {
         callback({
           status: xhr.status,


### PR DESCRIPTION
I found a critical issue that deadlocking scripts.

For example, on client PC that placed on very unstable wireless network, Google Chrome rarely raises `net::ERR_TIMED_OUT` from xhr.
Now Affjax does not handle a timeout path, then script gets stuck eternally, a continuation will be discarded.
I think xhr timeout must be handled with error callback.

And sorry I didn't know how to reproduce this, but I confirmed that this patch fixed the title issue by actual environment.

---

purs 0.12.2
Google Chrome Version 72.0.3626.81 (Official Build) (64-bit)
purescript-affjax with purescript-halogen
