### PR TITLE
On node.js don't override a base url already set in xhr2

### DIFF
--- a/src/Affjax.js
+++ b/src/Affjax.js
@@ -13,12 +13,16 @@ exports._ajax = function () {
       return new XHR();
     };
 
-    platformSpecific.fixupUrl = function (url) {
-      var urllib = module.require("url");
-      var u = urllib.parse(url);
-      u.protocol = u.protocol || "http:";
-      u.hostname = u.hostname || "localhost";
-      return urllib.format(u);
+    platformSpecific.fixupUrl = function (url, xhr) {
+      if (xhr.nodejsBaseUrl === null) {
+        var urllib = module.require("url");
+        var u = urllib.parse(url);
+        u.protocol = u.protocol || "http:";
+        u.hostname = u.hostname || "localhost";
+        return urllib.format(u);
+      } else {
+        return url || "/";
+      }
     };
 
     platformSpecific.getResponse = function (xhr) {
@@ -42,7 +46,7 @@ exports._ajax = function () {
   return function (mkHeader, options) {
     return function (errback, callback) {
       var xhr = platformSpecific.newXHR();
-      var fixedUrl = platformSpecific.fixupUrl(options.url);
+      var fixedUrl = platformSpecific.fixupUrl(options.url, xhr);
       xhr.open(options.method || "GET", fixedUrl, true, options.username, options.password);
       if (options.headers) {
         try {


### PR DESCRIPTION
xhr2 supports setting a base url globally on the prototype, using a static method.  I was trying to do this, so it was rather distressing to find Affjax overriding it with `localhost`:smile:

This PR makes `fixupUrl` detect whether the `xhr` object has a defined `nodejsBaseUrl`, and if so it just behaves the same way as in the browser version.  BTW the documentation comments say that this xhr2-only extension to the XHR API is "stable".