### PR TITLE
Type unsafe coercions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
     "test": "eslint src && pulp test"
   },
   "devDependencies": {
-    "eslint": "^3.10.1",
-    "body-parser": "^1.15.2",
-    "express": "^4.14.0",
-    "pulp": "^11.0.0",
-    "purescript-psa": "^0.5.0",
-    "purescript": "^0.12.0",
-    "rimraf": "^2.5.4",
-    "xhr2": "^0.1.3"
+    "eslint": "^6.3.0",
+    "body-parser": "^1.19.0",
+    "express": "^4.17.1",
+    "pulp": "^13.0.0",
+    "purescript-psa": "^0.7.3",
+    "purescript": "^0.13.3",
+    "rimraf": "^3.0.0",
+    "xhr2": "^0.2.0"
   }
 }

--- a/src/Affjax.js
+++ b/src/Affjax.js
@@ -1,6 +1,4 @@
-/* global exports */
 /* global XMLHttpRequest */
-/* global module */
 /* global process */
 "use strict";
 


### PR DESCRIPTION
Resolves #139

This will prevent potential problems arising when a too-new `purescript-form-urlencoded` is used.