### PR TITLE
Remove obsolete ResponseFormatError

### DIFF
--- a/src/Affjax/ResponseFormat.purs
+++ b/src/Affjax/ResponseFormat.purs
@@ -7,8 +7,6 @@ import Data.ArrayBuffer.Types (ArrayBuffer)
 import Data.Maybe (Maybe(..))
 import Data.MediaType (MediaType)
 import Data.MediaType.Common (applicationJSON)
-import Foreign (Foreign, ForeignError)
-import Foreign as Foreign
 import Web.DOM.Document (Document)
 import Web.File.Blob (Blob)
 
@@ -56,12 +54,3 @@ toMediaType =
   case _ of
     Json _ -> Just applicationJSON
     _ -> Nothing
-
--- | Used when an error occurs when attempting to decode into a particular
--- | response format. The error that occurred when decoding is included, along
--- | with the value that decoding was attempted on.
-data ResponseFormatError = ResponseFormatError ForeignError Foreign
-
-printResponseFormatError :: ResponseFormatError → String
-printResponseFormatError (ResponseFormatError err _) =
-  Foreign.renderForeignError err


### PR DESCRIPTION
As far as I can tell this is no longer used anywhere, see [here](https://github.com/slamdata/purescript-affjax/search?q=ResponseFormatError&unscoped_q=ResponseFormatError).